### PR TITLE
Make home scenarios section growth-friendly

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,9 +118,9 @@ const base = import.meta.env.BASE_URL;
   <!-- Scenarios -->
   <section class="scenarios" id="scenarios">
     <div class="container">
-      <p class="section-label">Scenarios</p>
-      <h2>Self-serve &rarr; flagship</h2>
-      <p class="scenarios__intro">Two end-to-end transcripts: a single-turn self-serve card reissue, then the full associate flagship with connected agents, policy-driven math, and a generated settlement.</p>
+      <p class="section-label">Walkthroughs</p>
+      <h2>Scenarios</h2>
+      <p class="scenarios__intro">End-to-end transcripts that put the building blocks to work, from a quick self-serve task to a full multi-agent flagship. More scenarios will land here over time.</p>
 
       <div class="scenarios__grid">
         <ScenarioCard


### PR DESCRIPTION
Removes the hardcoded "two transcripts / Self-serve → flagship" framing on the home page so the scenarios section scales as more are added. Retitles to **Scenarios** (with a "Walkthroughs" label) and notes more will land over time.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>