### PR TITLE
Theme-conditional hero copy (CAT subtitle + Modern Experience eyebrow)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,13 +23,24 @@ const base = import.meta.env.BASE_URL;
           <span class="t-bb">The retro-future game store, run by agents.</span>
         </p>
         <p class="hero__subtitle">
-          Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
-          moving from a single chatbot to coordinated, multi-agent systems. BlastBox Omega is a
-          complete, runnable reference: a parent agent that delegates to <strong>connected
-          agents</strong>, calls <strong>multiple inline MCP servers</strong>, runs
-          <strong>per-agent skills</strong> that generate and execute Python at runtime, and
-          returns real <strong>generated files</strong>. End-to-end reference scenarios
-          spanning <strong>agents and workflows</strong> in the new Copilot Studio.
+          <span class="t-cat">
+            Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
+            moving from a single chatbot to coordinated, multi-agent systems. This is a
+            <strong>technical guide from the CAT team</strong> on building enterprise-grade
+            scenarios on that new foundation: practical patterns for <strong>connected
+            agents</strong>, <strong>inline MCP servers</strong>, <strong>runtime skills</strong>,
+            and <strong>generated files</strong>, each one backed by a complete, runnable
+            reference you can deploy and inspect.
+          </span>
+          <span class="t-bb">
+            Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
+            moving from a single chatbot to coordinated, multi-agent systems. BlastBox Omega is a
+            complete, runnable reference: a parent agent that delegates to <strong>connected
+            agents</strong>, calls <strong>multiple inline MCP servers</strong>, runs
+            <strong>per-agent skills</strong> that generate and execute Python at runtime, and
+            returns real <strong>generated files</strong>. End-to-end reference scenarios
+            spanning <strong>agents and workflows</strong> in the new Copilot Studio.
+          </span>
         </p>
         <div class="hero__actions">
           <a href="#scenarios" class="btn btn--primary">Explore scenarios</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const base = import.meta.env.BASE_URL;
       <div class="hero__content">
         <div class="hero__eyebrow">
           <span class="hero__eyebrow-dot">&#9670;</span>
-          Copilot Studio &middot; Modern Agent Experience
+          Copilot Studio &middot; Modern Experience
         </div>
         <h1 class="hero__title">
           <span class="t-cat">The new <span class="hero__title-accent">Copilot Studio</span> experience</span>


### PR DESCRIPTION
Two small CAT-theme hero refinements:

- Make the hero subtitle theme-conditional: CAT framing describes the minisite as a CAT-team technical guide; BlastBox keeps its playful copy.
- Shorten the hero eyebrow to "Copilot Studio · Modern Experience".

Both verified in the local dev server across both themes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>