### PR TITLE
Add demo video render scripts + pipeline docs

### DIFF
--- a/scripts/video/README.md
+++ b/scripts/video/README.md
@@ -1,0 +1,177 @@
+# Demo video tooling
+
+Scripts that produced the looping flagship demo video on the **Block Party
+Trade-Up** scenario page (`src/pages/scenarios/block-party-trade-up.astro`).
+
+These are documented for **reuse of the technique**, not as a turnkey tool. The
+crop box, segment timings, and callout copy are all measured against one
+specific screen recording. Re-recording the agent (different window size,
+scroll positions, or conversation) means re-measuring the crop and re-timing
+every callout.
+
+> **Source recordings stay out of the repo.** The raw capture (~100MB `.mov`),
+> `trimmed.mp4`, `final.mp4`, and the generated frame sequences are large and
+> are intentionally not committed. Only these scripts and the final web asset
+> (`public/video/*.mp4` + poster) live in git.
+
+---
+
+## What you get
+
+Two render paths share the same overlay generator:
+
+1. **Continuous cut** — the full 2-minute walkthrough, chat on the right with a
+   persistent annotation card on the left whose content cross-fades per turn.
+2. **Highlights cut** (what currently ships) — holds each turn's *settled*
+   state and crossfades between them, ~54s. Sharper and shorter; embedded as a
+   looping `<video autoplay loop muted playsinline>` so it repeats like a GIF
+   but stays crisp.
+
+Each path comes in two palettes:
+
+| Generator | Palette | Use |
+| --- | --- | --- |
+| `make_overlays.py` | dark / near-black card | BlastBox theme |
+| `make_overlays_cat.py` | light / white card | CAT theme (default) |
+
+The CAT variant maps to the site palette: blue `#0078D4` (connected agents),
+purple `#7C3AED` (orchestrator / MCP), green `#16A34A` (Python skills). All
+primary text uses the `WHITE` constant, so flipping `WHITE` to a dark slate is
+what turns the whole panel into the light skin.
+
+---
+
+## Prerequisites
+
+| Tool | Notes |
+| --- | --- |
+| **ffmpeg** | trim, crop, alpha-merge corner rounding, overlay compositing, H.264, xfade |
+| **Python 3 + Pillow** | draws every annotation frame, the rounded-corner mask, the shadows |
+| **gifsicle** | only if you also want the (lower-quality) GIF fallback |
+| **SF Pro / SF Mono** | macOS system fonts (`/System/Library/Fonts/SFNS.ttf`, `SFNSMono.ttf`) |
+
+On macOS with Homebrew: `brew install ffmpeg gifsicle` and `pip install pillow`.
+
+All scripts use **relative paths** and expect to run from a working directory
+that contains your `trimmed.mp4` (and where `overlays*/`, `alt/`, output files
+get written).
+
+---
+
+## Pipeline
+
+```
+recording.mov
+   │  ① TRIM dead-air (tool-call spinners) → trimmed.mp4 (no audio)
+   ▼
+trimmed.mp4   ← reused unchanged by every render
+   │  ② OVERLAYS  → background.png, mask.png, per-segment panels
+   ▼
+   ├─③a CONTINUOUS  ffmpeg composite over every frame → final.mp4
+   └─③b HIGHLIGHTS  settled stills + crossfades → highlights-master.mp4
+            │  ④ (optional) → looping GIF
+            ▼
+   copy MP4 + poster into public/video/
+```
+
+### ① Trim
+
+Drop the 30–40s tool-call spinners between turns (per-second frame-difference
+motion analysis works well) so the timeline is just the moments the UI changes.
+Result: `trimmed.mp4` (the reference footage every render reuses).
+
+### ② Overlays
+
+```bash
+# assets: light/dark page background (+ drop shadows) and the rounded mask
+python3 make_overlays_cat.py assets       # → overlays_cat/{background,mask}.png
+
+# single settled panel for one segment (any time inside the segment, away from
+# a boundary, renders that segment's card at full alpha)
+python3 make_overlays_cat.py preview 52    # → overlays_cat/preview_52.0.png
+
+# full per-frame sequence (only needed for the CONTINUOUS cut)
+python3 make_overlays.py                    # → overlays/seq/f%05d.png
+```
+
+Segment content lives in `blocks_for()`; the six segments are
+`setup, t1, t2, t3, t4, summary`. Boundaries and the cross-fade timeline are in
+`BOUND` / `active()`. Edit copy there.
+
+### ③a Continuous composite (ffmpeg)
+
+```bash
+ffmpeg -y \
+  -loop 1 -i overlays/background.png \
+  -i trimmed.mp4 \
+  -i overlays/mask.png \
+  -framerate 30 -i overlays/seq/f%05d.png \
+  -filter_complex "
+    [1:v]crop=1590:1546:650:0,scale=1480:1439,fps=30[v];
+    [2:v]format=gray[m];
+    [v][m]alphamerge[vr];
+    [0:v][vr]overlay=1340:53[b];
+    [b][3:v]overlay=0:0:shortest=1,format=yuv420p[o]
+  " -map "[o]" -t 120 -c:v libx264 -preset medium -crf 20 -r 30 -an final.mp4
+```
+
+The crop box `1590:1546:650:0`, the chat placement `overlay=1340:53`, and the
+scale `1480:1439` are all measured for the reference recording. Re-measure if
+you re-record.
+
+### ③b Highlights cut (what ships)
+
+1. Pick a **settled-state time** per turn (the chat fully rendered, input box
+   clean, nothing mid-typing) by extracting candidate frames and eyeballing
+   them. Put the chat-still times in the extraction loop and the panel times in
+   `compose_cat_scenes.py` (`PANEL`).
+2. Extract + crop each chat still from `trimmed.mp4`:
+   ```bash
+   ffmpeg -y -ss <t> -i trimmed.mp4 -frames:v 1 \
+     -vf "crop=1590:1546:650:0,scale=1480:1439" alt/chat_<seg>.png
+   ```
+3. Composite each scene (background + rounded chat still + CAT panel):
+   ```bash
+   python3 compose_cat_scenes.py            # → alt/scene_<seg>.png
+   ```
+4. Build the crossfade video (hold durations + transition in `SCENES`/`T`):
+   ```bash
+   python3 build_highlights.py              # → alt/highlights-master.mp4
+   ```
+5. Copy into the site and regenerate the poster:
+   ```bash
+   cp alt/highlights-master.mp4 ../../public/video/block-party-trade-up-highlights.mp4
+   ffmpeg -y -i alt/scene_setup.png -vf scale=1920:-1 -frames:v 1 \
+     ../../public/video/block-party-trade-up-highlights-poster.jpg
+   ```
+
+### ④ Optional GIF
+
+`gif_build.py` renders each held scene as a single long-duration frame plus
+short crossfade frames on a shared palette, then you optimise with
+`gifsicle -O3 --lossy`. **Prefer the looping MP4** — a 256-color GIF is noticeably
+softer on text. Kept only as a no-`<video>` fallback technique.
+
+---
+
+## Embedding on the site
+
+```astro
+<video class="demo-video__player" autoplay loop muted playsinline preload="auto"
+       poster={`${base}video/<name>-poster.jpg`}>
+  <source src={`${base}video/<name>.mp4`} type="video/mp4" />
+</video>
+```
+
+`autoplay` requires `muted`; `loop` repeats it; no `controls` gives the GIF-like
+feel. The poster covers low-power modes that defer autoplay.
+
+---
+
+## PIL gotchas
+
+- A partial-alpha `ImageDraw` fill **replaces** alpha (punches a hole) rather
+  than blending. The `blend_rrect()` helper draws onto a separate transparent
+  layer and `alpha_composite`s it back. Used for every translucent rounded rect.
+- Square video corners can't be rounded by drawing over them. Use a real
+  grayscale rounded-rect mask (`mask.png`) applied with ffmpeg `alphamerge`.

--- a/scripts/video/build_highlights.py
+++ b/scripts/video/build_highlights.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Build the CAT-themed 'key moments' highlights cut.
+
+Holds each settled-state scene, crossfading between them. Keeps the original
+continuous video untouched. Outputs alt/highlights-master.mp4 (1080p-ish).
+"""
+import subprocess, os
+
+os.environ["PATH"] = "/opt/homebrew/bin:" + os.environ.get("PATH", "")
+
+OW, OH, FPS, T = 1920, 1022, 30, 0.7
+# (scene, hold seconds)
+SCENES = [
+    ("setup", 10.0),
+    ("t1", 9.0),
+    ("t2", 11.0),
+    ("t3", 8.0),
+    ("t4", 9.0),
+    ("summary", 10.0),
+]
+
+inputs = []
+for seg, d in SCENES:
+    inputs += ["-loop", "1", "-t", f"{d:.3f}", "-framerate", str(FPS),
+               "-i", f"alt/scene_{seg}.png"]
+
+# pre-process each input: scale + fps + format
+pre = []
+for i in range(len(SCENES)):
+    pre.append(
+        f"[{i}:v]scale={OW}:{OH}:force_original_aspect_ratio=decrease,"
+        f"pad={OW}:{OH}:(ow-iw)/2:(oh-ih)/2:color=0xECEDF2,"
+        f"fps={FPS},format=yuv420p,setsar=1[v{i}]"
+    )
+
+# xfade chain
+chain = []
+prev = "v0"
+acc = SCENES[0][1]
+for k in range(1, len(SCENES)):
+    off = acc - T
+    out = f"x{k}" if k < len(SCENES) - 1 else "vout"
+    chain.append(
+        f"[{prev}][v{k}]xfade=transition=fade:duration={T}:offset={off:.3f}[{out}]"
+    )
+    acc += SCENES[k][1] - T
+    prev = out
+
+fc = ";".join(pre + chain)
+total = sum(d for _, d in SCENES) - (len(SCENES) - 1) * T
+print(f"total duration ~ {total:.1f}s")
+
+cmd = ["ffmpeg", "-y", *inputs, "-filter_complex", fc,
+       "-map", "[vout]", "-c:v", "libx264", "-crf", "20",
+       "-preset", "medium", "-pix_fmt", "yuv420p", "-movflags", "+faststart",
+       "alt/highlights-master.mp4"]
+subprocess.run(cmd, check=True)
+print("wrote alt/highlights-master.mp4")

--- a/scripts/video/compose_cat_scenes.py
+++ b/scripts/video/compose_cat_scenes.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Compose held settled-state scenes for the CAT-themed highlights cut.
+
+Each scene = light background + rounded chat still (right) + CAT panel (left).
+Outputs alt/scene_<seg>.png at full master resolution (2906x1546).
+"""
+from PIL import Image
+
+W, H = 2906, 1546
+VID_W, VID_H, VID_X, VID_Y = 1480, 1439, 1340, 53
+
+SEGS = ["setup", "t1", "t2", "t3", "t4", "summary"]
+PANEL = {"setup": 3.0, "t1": 20.0, "t2": 52.0, "t3": 82.0, "t4": 103.0, "summary": 116.0}
+
+bg = Image.open("overlays_cat/background.png").convert("RGBA")
+mask = Image.open("overlays_cat/mask.png").convert("L")
+
+for seg in SEGS:
+    scene = bg.copy()
+    chat = Image.open(f"alt/chat_{seg}.png").convert("RGBA")
+    chat.putalpha(mask)
+    scene.alpha_composite(chat, (VID_X, VID_Y))
+    panel = Image.open(f"overlays_cat/preview_{PANEL[seg]:.1f}.png").convert("RGBA")
+    scene.alpha_composite(panel, (0, 0))
+    scene.convert("RGB").save(f"alt/scene_{seg}.png")
+    print("scene", seg, "ok")

--- a/scripts/video/gif_build.py
+++ b/scripts/video/gif_build.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Build a compact, seamlessly-looping GIF of the highlights cut.
+
+Each settled scene is ONE long-duration frame; only the crossfades emit
+short intermediate frames. A shared palette avoids inter-frame fl__.
+"""
+from PIL import Image
+
+GW = 1000  # gif width
+XF_FRAMES = 7
+XF_MS = 70           # per crossfade frame
+SCENES = [
+    ("setup", 9.0),
+    ("t1", 8.0),
+    ("t2", 10.0),
+    ("t3", 7.0),
+    ("t4", 8.0),
+    ("summary", 9.0),
+]
+
+def load(seg):
+    im = Image.open(f"alt/scene_{seg}.png").convert("RGB")
+    h = round(GW * im.height / im.width)
+    return im.resize((GW, h), Image.LANCZOS)
+
+scenes = {s: load(s) for s, _ in SCENES}
+
+# shared palette from all scenes stacked
+stack = Image.new("RGB", (GW, sum(im.height for im in scenes.values())))
+y = 0
+for im in scenes.values():
+    stack.paste(im, (0, y)); y += im.height
+pal_img = stack.quantize(colors=256, method=Image.MEDIANCUT, dither=Image.NONE)
+
+def to_p(rgb):
+    return rgb.quantize(palette=pal_img, dither=Image.FLOYDSTEINBERG)
+
+frames, durations = [], []
+n = len(SCENES)
+for i, (seg, hold) in enumerate(SCENES):
+    a = scenes[seg]
+    frames.append(to_p(a)); durations.append(int(hold * 1000))
+    nxt = scenes[SCENES[(i + 1) % n][0]]
+    for k in range(1, XF_FRAMES + 1):
+        alpha = k / (XF_FRAMES + 1)
+        frames.append(to_p(Image.blend(a, nxt, alpha)))
+        durations.append(XF_MS)
+
+frames[0].save(
+    "alt/highlights.gif", save_all=True, append_images=frames[1:],
+    duration=durations, loop=0, disposal=1, optimize=False,
+)
+print(f"frames={len(frames)} total~{sum(durations)/1000:.1f}s")

--- a/scripts/video/make_overlays.py
+++ b/scripts/video/make_overlays.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Block Party Trade-Up — polished demo overlays (v3).
+
+Layout: a PERSISTENT full-height annotation card on the LEFT whose inner
+content cross-fades through Setup -> Turn 1..4 -> Summary (card frame is
+always present, so there are no empty moments). The chat recording is
+cropped tight (no gutters), rounded-cornered and shadowed, on the RIGHT.
+
+Outputs:
+  - overlays/background.png  (light bg + soft card shadow, static)
+  - overlays/mask.png        (rounded-corner alpha mask for the video)
+  - overlays/seq/f*.png      (transparent left-card overlay per frame)
+Composited 1:1 over trimmed.mp4 by ffmpeg.
+"""
+import os, sys, shutil
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
+
+W, H = 2906, 1546
+FPS = 30
+DUR = 120.0
+SEQ = "overlays/seq"
+
+# ---- geometry ----------------------------------------------------------
+MARGIN = 86
+CARD_GAP = 64
+# chat (right)
+CROP_X, CROP_Y, CROP_W, CROP_H = 650, 0, 1590, 1546
+VID_W = 1480
+VID_H = round(VID_W * CROP_H / CROP_W)          # 1439
+VID_X = W - MARGIN - VID_W                        # 1340
+VID_Y = (H - VID_H) // 2                           # 53
+VID_R = 30                                          # corner radius
+# left card
+LX = MARGIN
+LW = VID_X - CARD_GAP - LX                          # 1190
+CARD_TOP = VID_Y
+CARD_H = VID_H
+PAD = 54
+
+# ---- fonts -------------------------------------------------------------
+SF = "/System/Library/Fonts/SFNS.ttf"
+MONO = "/System/Library/Fonts/SFNSMono.ttf"
+_fc = {}
+def font(size, weight="Regular", mono=False):
+    k = (size, weight, mono)
+    if k in _fc: return _fc[k]
+    f = ImageFont.truetype(MONO if mono else SF, size)
+    if not mono:
+        try: f.set_variation_by_name(weight)
+        except Exception: pass
+    _fc[k] = f
+    return f
+
+# ---- palette -----------------------------------------------------------
+ACCENT = (124, 122, 255)
+BLUE   = (96, 165, 250)
+EMER   = (52, 211, 153)
+CARD   = (15, 20, 38)
+CARD2  = (30, 38, 64)
+WHITE  = (255, 255, 255)
+SUB    = (203, 211, 230)
+MUTE   = (150, 160, 185)
+BG     = (236, 237, 242)
+
+def A(col, a): return col + (int(255*a),)
+
+# ---- helpers -----------------------------------------------------------
+def blend_rrect(img, box, r, fill=None, outline=None, width=1):
+    layer = Image.new("RGBA", img.size, (0,0,0,0))
+    ImageDraw.Draw(layer).rounded_rectangle(box, radius=r, fill=fill, outline=outline, width=width)
+    img.alpha_composite(layer)
+
+def wrap(text, fnt, maxw):
+    out, cur = [], ""
+    for w in text.split():
+        t = (cur+" "+w).strip()
+        if fnt.getlength(t) <= maxw: cur = t
+        else:
+            if cur: out.append(cur)
+            cur = w
+    if cur: out.append(cur)
+    return out
+
+def ease(t):
+    t = max(0.0, min(1.0, t)); return t*t*(3-2*t)
+
+# ---- fonts used in card -----------------------------------------------
+INNERW = LW - PAD*2
+def fonts():
+    return dict(
+        kick=font(32, "Bold"), title=font(68, "Bold"),
+        para=font(38, "Regular"), sub=font(27, "Bold"),
+        mlab=font(35, "Semibold"), mval=font(46, "Bold"),
+        slab=font(27, "Bold"), chip=font(30, "Regular", mono=True),
+        alab=font(28, "Bold"), aval=font(44, "Semibold"), anote=font(29, "Regular"),
+        rlab=font(28, "Bold"), rval=font(42, "Regular"),
+    )
+F = None
+
+# ---- block measure/draw ------------------------------------------------
+TITLE_LH, PARA_LH = 74, 51
+
+def measure(blocks):
+    h = 0
+    for b in blocks:
+        t = b["type"]
+        if t == "kicker": h += 46
+        elif t == "subhead": h += 50
+        elif t == "title":
+            h += len(wrap(b["text"], F["title"], INNERW))*TITLE_LH + 12
+        elif t == "para":
+            h += len(wrap(b["text"], F["para"], INNERW))*PARA_LH + 20
+        elif t == "metrics": h += len(b["items"])*100 + 6
+        elif t == "stack":
+            for lab, items, kind in b["sections"]:
+                h += 44
+                curx = 0; rows = 1
+                for it in items:
+                    wseg = F["chip"].getlength(it)+44+16
+                    if curx+wseg > INNERW: rows += 1; curx = 0
+                    curx += wseg
+                h += rows*60 + 16
+        elif t == "arch": h += len(b["rows"])*120
+        elif t == "results": h += len(b["rows"])*102
+        elif t == "gap": h += b["h"]
+    return h
+
+def draw_blocks(img, d, x, y, blocks, a):
+    ca = int(255*a)
+    for b in blocks:
+        t = b["type"]
+        if t == "kicker":
+            d.text((x, y), b["text"], font=F["kick"], fill=A(b.get("color",ACCENT), a)); y += 46
+        elif t == "subhead":
+            d.text((x, y+8), b["text"], font=F["sub"], fill=A(MUTE, a)); y += 50
+        elif t == "title":
+            for ln in wrap(b["text"], F["title"], INNERW):
+                d.text((x, y), ln, font=F["title"], fill=A(WHITE, a)); y += TITLE_LH
+            y += 12
+        elif t == "para":
+            for ln in wrap(b["text"], F["para"], INNERW):
+                d.text((x, y), ln, font=F["para"], fill=A(SUB, a)); y += PARA_LH
+            y += 20
+        elif t == "metrics":
+            y += 6
+            for lab, val, pos in b["items"]:
+                col = EMER if pos else WHITE
+                blend_rrect(img, [x, y, x+INNERW, y+84], 16, fill=A(CARD2, 0.92*a))
+                d.text((x+26, y+24), lab, font=F["mlab"], fill=A(SUB, a))
+                d.text((x+INNERW-26-F["mval"].getlength(val), y+18), val, font=F["mval"], fill=A(col, a))
+                y += 100
+        elif t == "stack":
+            for lab, items, kind in b["sections"]:
+                col = {"agent":BLUE,"mcp":ACCENT,"skill":EMER}[kind]
+                d.text((x, y), lab, font=F["slab"], fill=A(MUTE, a)); y += 44
+                curx = x
+                for it in items:
+                    wseg = F["chip"].getlength(it)+44
+                    if curx+wseg > x+INNERW: curx = x; y += 60
+                    blend_rrect(img, [curx, y, curx+wseg, y+50], 12, fill=A(CARD2, 0.92*a), outline=A(col, 0.6*a), width=2)
+                    d.text((curx+22, y+9), it, font=F["chip"], fill=A(col, a))
+                    curx += wseg + 16
+                y += 60 + 16
+        elif t == "arch":
+            for lab, val, note, col in b["rows"]:
+                d.text((x, y), lab, font=F["alab"], fill=A(col, a))
+                d.text((x, y+36), val, font=F["aval"], fill=A(WHITE, a))
+                d.text((x, y+88), note, font=F["anote"], fill=A(MUTE, a))
+                y += 120
+        elif t == "results":
+            for lab, val, col in b["rows"]:
+                d.text((x, y), lab, font=F["rlab"], fill=A(ACCENT, a))
+                d.text((x, y+36), val, font=F["rval"], fill=A(col, a))
+                y += 102
+        elif t == "gap":
+            y += b["h"]
+    return y
+
+# ---- card frame + content ---------------------------------------------
+def render_card(segblocks_alpha_pairs):
+    """segblocks_alpha_pairs: list of (blocks, alpha). Card frame always full."""
+    img = Image.new("RGBA", (W, H), (0,0,0,0)); d = ImageDraw.Draw(img)
+    blend_rrect(img, [LX, CARD_TOP, LX+LW, CARD_TOP+CARD_H], 30, fill=A(CARD, 0.95), outline=A(ACCENT, 0.45), width=2)
+    for blocks, a in segblocks_alpha_pairs:
+        if a <= 0.003: continue
+        h = measure(blocks)
+        y0 = CARD_TOP + max(PAD, (CARD_H - h)//2)
+        draw_blocks(img, d, LX+PAD, y0, blocks, a)
+    return img
+
+# ===== SEGMENT CONTENT ==================================================
+def blocks_for(seg):
+    if seg == "setup":
+        return [
+            {"type":"kicker","text":"THE SCENARIO","color":ACCENT},
+            {"type":"title","text":"Block Party Trade-Up"},
+            {"type":"para","text":"A customer's BlastBox console died days before the neighborhood block party. The associate just types plain-language requests — one Copilot Studio agent orchestrates the entire resolution."},
+            {"type":"subhead","text":"THE STACK"},
+            {"type":"arch","rows":[
+                ("ORCHESTRATOR","Store Associate Assistant","generative orchestration",ACCENT),
+                ("CONNECTED AGENTS","Store Policy · Inventory & Fulfillment","child agents",BLUE),
+                ("MCP SERVERS","Membership MCP v2 · Order Management MCP","streamable tools",ACCENT),
+                ("PYTHON SKILLS","prorated-refund · points-reconciliation · slip-pdf","code interpreter",EMER),
+            ]},
+        ]
+    if seg == "t1":
+        return [
+            {"type":"kicker","text":"TURN 1 / 4"},
+            {"type":"title","text":"The Ask"},
+            {"type":"para","text":"The associate relays the situation: a dead BlastBox console, a block party this Saturday, and a request to cancel BlastPass."},
+            {"type":"para","text":"The orchestrator fans out in parallel — policy to the Store Policy Agent, stock to the Inventory & Fulfillment Agent — then calls Membership MCP v2 to load the account and read the BlastPoints balance (4,200) itself, never asking the associate."},
+            {"type":"stack","sections":[
+                ("CONNECTED AGENTS",["Store Policy","Inventory & Fulfillment"],"agent"),
+                ("MEMBERSHIP MCP v2",["get_membership"],"mcp"),
+            ]},
+        ]
+    if seg == "t2":
+        return [
+            {"type":"kicker","text":"TURN 2 / 4"},
+            {"type":"title","text":"Ruling + Live Math"},
+            {"type":"para","text":"Associate confirms a manufacturing fault. The Store Policy Agent rules: free warranty swap, no restocking fee. The prorated-refund-calculator skill runs the unused-BlastPass math on the spot while Inventory confirms MEGA Edition stock."},
+            {"type":"metrics","items":[
+                ("Prorated BlastPass refund","$76.66",False),
+                ("Net due after upgrade","$23.34",False),
+            ]},
+            {"type":"stack","sections":[
+                ("PYTHON SKILL",["prorated-refund-calculator"],"skill"),
+                ("CONNECTED AGENT",["Inventory & Fulfillment"],"agent"),
+            ]},
+        ]
+    if seg == "t3":
+        return [
+            {"type":"kicker","text":"TURN 3 / 4"},
+            {"type":"title","text":"Closing the Customer"},
+            {"type":"para","text":"The customer is on the fence about upgrading. The orchestrator queries the Inventory & Fulfillment Agent for MEGA-Edition–exclusive titles."},
+            {"type":"para","text":"It surfaces three real AAA games available only on MEGA — grounded in the live catalog, with no invented SKUs — to turn the upgrade into an easy yes."},
+            {"type":"stack","sections":[
+                ("CONNECTED AGENT",["Inventory & Fulfillment"],"agent"),
+            ]},
+        ]
+    if seg == "t4":
+        return [
+            {"type":"kicker","text":"TURN 4 / 4"},
+            {"type":"title","text":"Execute & Settle"},
+            {"type":"para","text":"A single instruction drives the full settlement across both MCP servers and all three Python skills, in dependency order."},
+            {"type":"metrics","items":[
+                ("BlastPoints redeemed","21,400 → $105",True),
+                ("Net due settled","$23.34",False),
+            ]},
+            {"type":"stack","sections":[
+                ("ORDER MANAGEMENT MCP",["search_orders","get_order","request_return"],"mcp"),
+                ("MEMBERSHIP MCP v2",["cancel_membership"],"mcp"),
+                ("PYTHON SKILLS",["points-reconciliation","slip-pdf-generator"],"skill"),
+            ]},
+        ]
+    if seg == "summary":
+        return [
+            {"type":"kicker","text":"RESOLVED IN ONE VISIT","color":EMER},
+            {"type":"title","text":"Settled at the counter"},
+            {"type":"results","rows":[
+                ("DEFECTIVE CONSOLE","Free warranty swap into the MEGA Edition",WHITE),
+                ("PRORATED REFUND","$76.66 applied as store credit",WHITE),
+                ("NET DUE AFTER UPGRADE","$23.34",WHITE),
+                ("BLASTPOINTS REDEEMED","21,400 pts  →  $105.00 off the balance",EMER),
+                ("PAPERWORK","BlastPass cancelled · RA-50022 · slip PDF printed",WHITE),
+            ]},
+        ]
+    return []
+
+# ===== TIMELINE =========================================================
+# segment containing t, plus cross-fades at boundaries
+ORDER = ["setup","t1","t2","t3","t4","summary"]
+BOUND = [  # (time, before, after)
+    (7.0, "setup", "t1"),
+    (34.0, "t1", "t2"),
+    (70.0, "t2", "t3"),
+    (95.0, "t3", "t4"),
+    (112.0, "t4", "summary"),
+]
+HW = 0.35
+def seg_of(t):
+    s = "setup"
+    for tb, b, a in BOUND:
+        if t >= tb: s = a
+    return s
+def active(t):
+    for tb, b, a in BOUND:
+        if abs(t - tb) < HW:
+            f = ease((t-(tb-HW))/(2*HW))
+            return [(b, round(1-f,3)), (a, round(f,3))]
+    return [(seg_of(t), 1.0)]
+
+_bcache = {}
+def blocks_cached(seg):
+    if seg not in _bcache: _bcache[seg] = blocks_for(seg)
+    return _bcache[seg]
+
+def build(t):
+    pairs = [(blocks_cached(s), a) for s, a in active(t)]
+    return render_card(pairs)
+
+# ===== STATIC ASSETS ====================================================
+def make_background():
+    img = Image.new("RGB", (W, H), BG).convert("RGBA")
+    sh = Image.new("RGBA", (W, H), (0,0,0,0))
+    for box, rad, col in [
+        ([VID_X+8, VID_Y+20, VID_X+VID_W+8, VID_Y+VID_H+30], 40, (20,24,45,120)),     # chat shadow
+        ([LX+6, CARD_TOP+18, LX+LW+6, CARD_TOP+CARD_H+26], 36, (20,24,45,110)),         # left card shadow
+    ]:
+        ImageDraw.Draw(sh).rounded_rectangle(box, radius=rad, fill=col)
+    sh = sh.filter(ImageFilter.GaussianBlur(30))
+    img.alpha_composite(sh)
+    img.convert("RGB").save("overlays/background.png")
+    print("bg ok | chat", VID_X, VID_Y, VID_W, VID_H, "| left", LX, CARD_TOP, LW, CARD_H)
+
+def make_mask():
+    m = Image.new("L", (VID_W, VID_H), 0)
+    ImageDraw.Draw(m).rounded_rectangle([0, 0, VID_W-1, VID_H-1], radius=VID_R, fill=255)
+    m.save("overlays/mask.png")
+    print("mask ok", VID_W, VID_H, "r", VID_R)
+
+# ===== MAIN =============================================================
+def main():
+    global F
+    F = fonts()
+    if len(sys.argv) >= 2 and sys.argv[1] == "assets":
+        os.makedirs("overlays", exist_ok=True); make_background(); make_mask(); return
+    if len(sys.argv) >= 3 and sys.argv[1] == "preview":
+        t = float(sys.argv[2]); build(t).save(f"overlays/preview_{t:.1f}.png")
+        print("wrote", f"overlays/preview_{t:.1f}.png"); return
+    os.makedirs(SEQ, exist_ok=True)
+    n = int(DUR*FPS); cache = {}
+    for i in range(n):
+        t = i/FPS; sig = tuple(active(t)); path = f"{SEQ}/f{i:05d}.png"
+        if sig in cache: shutil.copy(cache[sig], path)
+        else:
+            build(t).save(path); cache[sig] = path
+        if i % 450 == 0: print(f"frame {i}/{n} t={t:.1f} {sig} unique={len(cache)}")
+    print("done", n, "frames, unique", len(cache))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/video/make_overlays_cat.py
+++ b/scripts/video/make_overlays_cat.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Block Party Trade-Up — polished demo overlays (v3).
+
+Layout: a PERSISTENT full-height annotation card on the LEFT whose inner
+content cross-fades through Setup -> Turn 1..4 -> Summary (card frame is
+always present, so there are no empty moments). The chat recording is
+cropped tight (no gutters), rounded-cornered and shadowed, on the RIGHT.
+
+Outputs:
+  - overlays/background.png  (light bg + soft card shadow, static)
+  - overlays/mask.png        (rounded-corner alpha mask for the video)
+  - overlays/seq/f*.png      (transparent left-card overlay per frame)
+Composited 1:1 over trimmed.mp4 by ffmpeg.
+"""
+import os, sys, shutil
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
+
+W, H = 2906, 1546
+FPS = 30
+DUR = 120.0
+SEQ = "overlays_cat/seq"
+OUTDIR = "overlays_cat"
+
+# ---- geometry ----------------------------------------------------------
+MARGIN = 86
+CARD_GAP = 64
+# chat (right)
+CROP_X, CROP_Y, CROP_W, CROP_H = 650, 0, 1590, 1546
+VID_W = 1480
+VID_H = round(VID_W * CROP_H / CROP_W)          # 1439
+VID_X = W - MARGIN - VID_W                        # 1340
+VID_Y = (H - VID_H) // 2                           # 53
+VID_R = 30                                          # corner radius
+# left card
+LX = MARGIN
+LW = VID_X - CARD_GAP - LX                          # 1190
+CARD_TOP = VID_Y
+CARD_H = VID_H
+PAD = 54
+
+# ---- fonts -------------------------------------------------------------
+SF = "/System/Library/Fonts/SFNS.ttf"
+MONO = "/System/Library/Fonts/SFNSMono.ttf"
+_fc = {}
+def font(size, weight="Regular", mono=False):
+    k = (size, weight, mono)
+    if k in _fc: return _fc[k]
+    f = ImageFont.truetype(MONO if mono else SF, size)
+    if not mono:
+        try: f.set_variation_by_name(weight)
+        except Exception: pass
+    _fc[k] = f
+    return f
+
+# ---- palette (CAT theme: light professional surface) -------------------
+# Maps to the site's CAT palette: blue #0078D4, purple #7C3AED, green #16A34A.
+# Primary text uses WHITE constant throughout, so WHITE -> dark slate flips
+# the whole panel to a light skin in one place.
+ACCENT = (124, 58, 237)     # purple  #7C3AED  (orchestrator / MCP)
+BLUE   = (0, 120, 212)      # blue    #0078D4  (connected agents)
+EMER   = (22, 163, 74)      # green   #16A34A  (python skills)
+CARD   = (255, 255, 255)    # white card fill
+CARD2  = (241, 245, 249)    # slate-100 chip / metric fill
+WHITE  = (15, 23, 42)       # slate-900 = primary text on the light card
+SUB    = (51, 65, 85)       # slate-700 body text
+MUTE   = (100, 116, 139)    # slate-500 labels
+BORDER = (213, 219, 230)    # neutral card border
+BG     = (236, 237, 242)    # page background
+
+def A(col, a): return col + (int(255*a),)
+
+# ---- helpers -----------------------------------------------------------
+def blend_rrect(img, box, r, fill=None, outline=None, width=1):
+    layer = Image.new("RGBA", img.size, (0,0,0,0))
+    ImageDraw.Draw(layer).rounded_rectangle(box, radius=r, fill=fill, outline=outline, width=width)
+    img.alpha_composite(layer)
+
+def wrap(text, fnt, maxw):
+    out, cur = [], ""
+    for w in text.split():
+        t = (cur+" "+w).strip()
+        if fnt.getlength(t) <= maxw: cur = t
+        else:
+            if cur: out.append(cur)
+            cur = w
+    if cur: out.append(cur)
+    return out
+
+def ease(t):
+    t = max(0.0, min(1.0, t)); return t*t*(3-2*t)
+
+# ---- fonts used in card -----------------------------------------------
+INNERW = LW - PAD*2
+def fonts():
+    return dict(
+        kick=font(32, "Bold"), title=font(68, "Bold"),
+        para=font(38, "Regular"), sub=font(27, "Bold"),
+        mlab=font(35, "Semibold"), mval=font(46, "Bold"),
+        slab=font(27, "Bold"), chip=font(30, "Regular", mono=True),
+        alab=font(28, "Bold"), aval=font(44, "Semibold"), anote=font(29, "Regular"),
+        rlab=font(28, "Bold"), rval=font(42, "Regular"),
+    )
+F = None
+
+# ---- block measure/draw ------------------------------------------------
+TITLE_LH, PARA_LH = 74, 51
+
+def measure(blocks):
+    h = 0
+    for b in blocks:
+        t = b["type"]
+        if t == "kicker": h += 46
+        elif t == "subhead": h += 50
+        elif t == "title":
+            h += len(wrap(b["text"], F["title"], INNERW))*TITLE_LH + 12
+        elif t == "para":
+            h += len(wrap(b["text"], F["para"], INNERW))*PARA_LH + 20
+        elif t == "metrics": h += len(b["items"])*100 + 6
+        elif t == "stack":
+            for lab, items, kind in b["sections"]:
+                h += 44
+                curx = 0; rows = 1
+                for it in items:
+                    wseg = F["chip"].getlength(it)+44+16
+                    if curx+wseg > INNERW: rows += 1; curx = 0
+                    curx += wseg
+                h += rows*60 + 16
+        elif t == "arch": h += len(b["rows"])*120
+        elif t == "results": h += len(b["rows"])*102
+        elif t == "gap": h += b["h"]
+    return h
+
+def draw_blocks(img, d, x, y, blocks, a):
+    ca = int(255*a)
+    for b in blocks:
+        t = b["type"]
+        if t == "kicker":
+            d.text((x, y), b["text"], font=F["kick"], fill=A(b.get("color",ACCENT), a)); y += 46
+        elif t == "subhead":
+            d.text((x, y+8), b["text"], font=F["sub"], fill=A(MUTE, a)); y += 50
+        elif t == "title":
+            for ln in wrap(b["text"], F["title"], INNERW):
+                d.text((x, y), ln, font=F["title"], fill=A(WHITE, a)); y += TITLE_LH
+            y += 12
+        elif t == "para":
+            for ln in wrap(b["text"], F["para"], INNERW):
+                d.text((x, y), ln, font=F["para"], fill=A(SUB, a)); y += PARA_LH
+            y += 20
+        elif t == "metrics":
+            y += 6
+            for lab, val, pos in b["items"]:
+                col = EMER if pos else WHITE
+                blend_rrect(img, [x, y, x+INNERW, y+84], 16, fill=A(CARD2, a), outline=A(BORDER, a), width=2)
+                d.text((x+26, y+24), lab, font=F["mlab"], fill=A(SUB, a))
+                d.text((x+INNERW-26-F["mval"].getlength(val), y+18), val, font=F["mval"], fill=A(col, a))
+                y += 100
+        elif t == "stack":
+            for lab, items, kind in b["sections"]:
+                col = {"agent":BLUE,"mcp":ACCENT,"skill":EMER}[kind]
+                d.text((x, y), lab, font=F["slab"], fill=A(MUTE, a)); y += 44
+                curx = x
+                for it in items:
+                    wseg = F["chip"].getlength(it)+44
+                    if curx+wseg > x+INNERW: curx = x; y += 60
+                    blend_rrect(img, [curx, y, curx+wseg, y+50], 12, fill=A(CARD2, 0.92*a), outline=A(col, 0.6*a), width=2)
+                    d.text((curx+22, y+9), it, font=F["chip"], fill=A(col, a))
+                    curx += wseg + 16
+                y += 60 + 16
+        elif t == "arch":
+            for lab, val, note, col in b["rows"]:
+                d.text((x, y), lab, font=F["alab"], fill=A(col, a))
+                d.text((x, y+36), val, font=F["aval"], fill=A(WHITE, a))
+                d.text((x, y+88), note, font=F["anote"], fill=A(MUTE, a))
+                y += 120
+        elif t == "results":
+            for lab, val, col in b["rows"]:
+                d.text((x, y), lab, font=F["rlab"], fill=A(ACCENT, a))
+                d.text((x, y+36), val, font=F["rval"], fill=A(col, a))
+                y += 102
+        elif t == "gap":
+            y += b["h"]
+    return y
+
+# ---- card frame + content ---------------------------------------------
+def render_card(segblocks_alpha_pairs):
+    """segblocks_alpha_pairs: list of (blocks, alpha). Card frame always full."""
+    img = Image.new("RGBA", (W, H), (0,0,0,0)); d = ImageDraw.Draw(img)
+    blend_rrect(img, [LX, CARD_TOP, LX+LW, CARD_TOP+CARD_H], 30, fill=A(CARD, 1.0), outline=A(BORDER, 1.0), width=2)
+    for blocks, a in segblocks_alpha_pairs:
+        if a <= 0.003: continue
+        h = measure(blocks)
+        y0 = CARD_TOP + max(PAD, (CARD_H - h)//2)
+        draw_blocks(img, d, LX+PAD, y0, blocks, a)
+    return img
+
+# ===== SEGMENT CONTENT ==================================================
+def blocks_for(seg):
+    if seg == "setup":
+        return [
+            {"type":"kicker","text":"THE SCENARIO","color":ACCENT},
+            {"type":"title","text":"Block Party Trade-Up"},
+            {"type":"para","text":"A customer's BlastBox console died days before the neighborhood block party. The associate just types plain-language requests — one Copilot Studio agent orchestrates the entire resolution."},
+            {"type":"subhead","text":"THE STACK"},
+            {"type":"arch","rows":[
+                ("ORCHESTRATOR","Store Associate Assistant","generative orchestration",ACCENT),
+                ("CONNECTED AGENTS","Store Policy · Inventory & Fulfillment","child agents",BLUE),
+                ("MCP SERVERS","Membership MCP v2 · Order Management MCP","streamable tools",ACCENT),
+                ("PYTHON SKILLS","prorated-refund · points-reconciliation · slip-pdf","code interpreter",EMER),
+            ]},
+        ]
+    if seg == "t1":
+        return [
+            {"type":"kicker","text":"TURN 1 / 4"},
+            {"type":"title","text":"The Ask"},
+            {"type":"para","text":"The associate relays the situation: a dead BlastBox console, a block party this Saturday, and a request to cancel BlastPass."},
+            {"type":"para","text":"The orchestrator fans out in parallel — policy to the Store Policy Agent, stock to the Inventory & Fulfillment Agent — then calls Membership MCP v2 to load the account and read the BlastPoints balance (4,200) itself, never asking the associate."},
+            {"type":"stack","sections":[
+                ("CONNECTED AGENTS",["Store Policy","Inventory & Fulfillment"],"agent"),
+                ("MEMBERSHIP MCP v2",["get_membership"],"mcp"),
+            ]},
+        ]
+    if seg == "t2":
+        return [
+            {"type":"kicker","text":"TURN 2 / 4"},
+            {"type":"title","text":"Ruling + Live Math"},
+            {"type":"para","text":"Associate confirms a manufacturing fault. The Store Policy Agent rules: free warranty swap, no restocking fee. The prorated-refund-calculator skill runs the unused-BlastPass math on the spot while Inventory confirms MEGA Edition stock."},
+            {"type":"metrics","items":[
+                ("Prorated BlastPass refund","$76.66",False),
+                ("Net due after upgrade","$23.34",False),
+            ]},
+            {"type":"stack","sections":[
+                ("PYTHON SKILL",["prorated-refund-calculator"],"skill"),
+                ("CONNECTED AGENT",["Inventory & Fulfillment"],"agent"),
+            ]},
+        ]
+    if seg == "t3":
+        return [
+            {"type":"kicker","text":"TURN 3 / 4"},
+            {"type":"title","text":"Closing the Customer"},
+            {"type":"para","text":"The customer is on the fence about upgrading. The orchestrator queries the Inventory & Fulfillment Agent for MEGA-Edition–exclusive titles."},
+            {"type":"para","text":"It surfaces three real AAA games available only on MEGA — grounded in the live catalog, with no invented SKUs — to turn the upgrade into an easy yes."},
+            {"type":"stack","sections":[
+                ("CONNECTED AGENT",["Inventory & Fulfillment"],"agent"),
+            ]},
+        ]
+    if seg == "t4":
+        return [
+            {"type":"kicker","text":"TURN 4 / 4"},
+            {"type":"title","text":"Execute & Settle"},
+            {"type":"para","text":"A single instruction drives the full settlement across both MCP servers and all three Python skills, in dependency order."},
+            {"type":"metrics","items":[
+                ("BlastPoints redeemed","21,400 → $105",True),
+                ("Net due settled","$23.34",False),
+            ]},
+            {"type":"stack","sections":[
+                ("ORDER MANAGEMENT MCP",["search_orders","get_order","request_return"],"mcp"),
+                ("MEMBERSHIP MCP v2",["cancel_membership"],"mcp"),
+                ("PYTHON SKILLS",["points-reconciliation","slip-pdf-generator"],"skill"),
+            ]},
+        ]
+    if seg == "summary":
+        return [
+            {"type":"kicker","text":"RESOLVED IN ONE VISIT","color":EMER},
+            {"type":"title","text":"Settled at the counter"},
+            {"type":"results","rows":[
+                ("DEFECTIVE CONSOLE","Free warranty swap into the MEGA Edition",WHITE),
+                ("PRORATED REFUND","$76.66 applied as store credit",WHITE),
+                ("NET DUE AFTER UPGRADE","$23.34",WHITE),
+                ("BLASTPOINTS REDEEMED","21,400 pts  →  $105.00 off the balance",EMER),
+                ("PAPERWORK","BlastPass cancelled · RA-50022 · slip PDF printed",WHITE),
+            ]},
+        ]
+    return []
+
+# ===== TIMELINE =========================================================
+# segment containing t, plus cross-fades at boundaries
+ORDER = ["setup","t1","t2","t3","t4","summary"]
+BOUND = [  # (time, before, after)
+    (7.0, "setup", "t1"),
+    (34.0, "t1", "t2"),
+    (70.0, "t2", "t3"),
+    (95.0, "t3", "t4"),
+    (112.0, "t4", "summary"),
+]
+HW = 0.35
+def seg_of(t):
+    s = "setup"
+    for tb, b, a in BOUND:
+        if t >= tb: s = a
+    return s
+def active(t):
+    for tb, b, a in BOUND:
+        if abs(t - tb) < HW:
+            f = ease((t-(tb-HW))/(2*HW))
+            return [(b, round(1-f,3)), (a, round(f,3))]
+    return [(seg_of(t), 1.0)]
+
+_bcache = {}
+def blocks_cached(seg):
+    if seg not in _bcache: _bcache[seg] = blocks_for(seg)
+    return _bcache[seg]
+
+def build(t):
+    pairs = [(blocks_cached(s), a) for s, a in active(t)]
+    return render_card(pairs)
+
+# ===== STATIC ASSETS ====================================================
+def make_background():
+    img = Image.new("RGB", (W, H), BG).convert("RGBA")
+    sh = Image.new("RGBA", (W, H), (0,0,0,0))
+    for box, rad, col in [
+        ([VID_X+8, VID_Y+20, VID_X+VID_W+8, VID_Y+VID_H+30], 40, (20,24,45,120)),     # chat shadow
+        ([LX+6, CARD_TOP+18, LX+LW+6, CARD_TOP+CARD_H+26], 36, (20,24,45,110)),         # left card shadow
+    ]:
+        ImageDraw.Draw(sh).rounded_rectangle(box, radius=rad, fill=col)
+    sh = sh.filter(ImageFilter.GaussianBlur(30))
+    img.alpha_composite(sh)
+    img.convert("RGB").save(f"{OUTDIR}/background.png")
+    print("bg ok | chat", VID_X, VID_Y, VID_W, VID_H, "| left", LX, CARD_TOP, LW, CARD_H)
+
+def make_mask():
+    m = Image.new("L", (VID_W, VID_H), 0)
+    ImageDraw.Draw(m).rounded_rectangle([0, 0, VID_W-1, VID_H-1], radius=VID_R, fill=255)
+    m.save(f"{OUTDIR}/mask.png")
+    print("mask ok", VID_W, VID_H, "r", VID_R)
+
+# ===== MAIN =============================================================
+def main():
+    global F
+    F = fonts()
+    if len(sys.argv) >= 2 and sys.argv[1] == "assets":
+        os.makedirs(OUTDIR, exist_ok=True); make_background(); make_mask(); return
+    if len(sys.argv) >= 3 and sys.argv[1] == "preview":
+        os.makedirs(OUTDIR, exist_ok=True)
+        t = float(sys.argv[2]); build(t).save(f"{OUTDIR}/preview_{t:.1f}.png")
+        print("wrote", f"{OUTDIR}/preview_{t:.1f}.png"); return
+    os.makedirs(SEQ, exist_ok=True)
+    n = int(DUR*FPS); cache = {}
+    for i in range(n):
+        t = i/FPS; sig = tuple(active(t)); path = f"{SEQ}/f{i:05d}.png"
+        if sig in cache: shutil.copy(cache[sig], path)
+        else:
+            build(t).save(path); cache[sig] = path
+        if i % 450 == 0: print(f"frame {i}/{n} t={t:.1f} {sig} unique={len(cache)}")
+    print("done", n, "frames, unique", len(cache))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Versions the tooling behind the flagship demo video so anyone adding scenario videos can reuse the technique.

Adds `scripts/video/`:
- `make_overlays.py` (dark/BlastBox palette) and `make_overlays_cat.py` (CAT/light palette) — the annotation panel generator.
- `compose_cat_scenes.py` — composites settled chat stills + CAT panels into per-turn scenes.
- `build_highlights.py` — assembles the held-state + crossfade highlights MP4.
- `gif_build.py` — optional looping GIF fallback.
- `README.md` — prerequisites, full pipeline (trim → overlays → composite/highlights → embed), color legend, and PIL gotchas.

Large source recordings (the raw .mov, trimmed.mp4, final.mp4, frame sequences) intentionally stay out of the repo; only the scripts and the final web asset are committed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>