### PR TITLE
Add Microsoft Clarity analytics (prod-only, env-configurable)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Microsoft Clarity project id used for site analytics.
+# Optional: the layout falls back to the default project id if unset.
+# Only loaded in production builds (never on `npm run dev`).
+PUBLIC_CLARITY_ID=xafqjylsli

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ npm run dev        # http://localhost:4321/new-copilot-studio-tech-guide/
 npm run build      # Build to ./dist/
 ```
 
+Site analytics use [Microsoft Clarity](https://clarity.microsoft.com/), loaded in
+production builds only (never on `npm run dev`). Override the project id with the
+`PUBLIC_CLARITY_ID` env var — see [`.env.example`](./.env.example).
+
 ## Contributing
 
 This project welcomes contributions and suggestions. See [CONTRIBUTING](https://github.com/microsoft/new-copilot-studio-tech-guide/blob/main/CONTRIBUTING.md) for details.

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -9,6 +9,11 @@ interface Props {
 const { title, description = 'A technical guide to the new AI workloads in Copilot Studio Agents and Workflows' } = Astro.props;
 const base = import.meta.env.BASE_URL;
 const repo = 'https://github.com/microsoft/new-copilot-studio-tech-guide';
+
+// Microsoft Clarity analytics. Loads in production builds only (never on
+// localhost dev). Project id is overridable via PUBLIC_CLARITY_ID.
+const clarityId = import.meta.env.PUBLIC_CLARITY_ID ?? 'xafqjylsli';
+const enableClarity = import.meta.env.PROD;
 ---
 
 <!doctype html>
@@ -19,6 +24,15 @@ const repo = 'https://github.com/microsoft/new-copilot-studio-tech-guide';
     <meta name="description" content={description} />
     <link rel="icon" type="image/png" href={`${base}favicon.png`} />
     <title>{title}</title>
+    {enableClarity && (
+      <script is:inline define:vars={{ clarityId }}>
+        (function (c, l, a, r, i, t, y) {
+          c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };
+          t = l.createElement(r); t.async = 1; t.src = 'https://www.clarity.ms/tag/' + i;
+          y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+        })(window, document, 'clarity', 'script', clarityId);
+      </script>
+    )}
     <script is:inline>
       // Apply the saved skin before first paint (avoids a flash). Default = CAT.
       (function () {


### PR DESCRIPTION
Adds Microsoft Clarity page analytics (project `xafqjylsli`) to the site.

- Loader injected once via the shared `Base.astro` layout, gated on `import.meta.env.PROD` so it loads in **production builds only** (never on `npm run dev`).
- Project id reads from `PUBLIC_CLARITY_ID` with a hardcoded fallback; documented in `.env.example` and the README.

**Validated:** Clarity present in all 4 `dist/*.html` pages after `npm run build`; absent in dev render.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>