### PR TITLE
Point deep-dive deck link to external aka.ms URL

### DIFF
--- a/public/files/modern-agents-deep-dive.pptx
+++ b/public/files/modern-agents-deep-dive.pptx
@@ -1,1 +1,0 @@
-placeholder deck - replace this file with the real modern-agents-deep-dive.pptx

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -229,7 +229,7 @@ const base = import.meta.env.BASE_URL;
       <p class="resources__intro">Reference material to help you understand and extend the new Copilot Studio agent experience, a technical deep dive on modern agents and the open-source plugin that ties into it.</p>
 
       <div class="resources__grid">
-        <a href={`${base}files/modern-agents-deep-dive.pptx`} class="resource" download>
+        <a href="https://aka.ms/CopilotStudioDeepDiveDeck" class="resource" target="_blank" rel="noopener">
           <span class="resource__icon resource__icon--deck">
             <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="12" y1="17" x2="12" y2="21"/><line x1="8" y1="21" x2="16" y2="21"/></svg>
           </span>
@@ -238,8 +238,8 @@ const base = import.meta.env.BASE_URL;
             <h3 class="resource__title">Modern Agents technical deep dive</h3>
             <p class="resource__desc">A slide-by-slide walkthrough of the architecture behind the new Copilot Studio agents, connected agents, MCP, skills, orchestration, and file generation.</p>
             <span class="resource__link">
-              Download the deck
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              Open the deck
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><polyline points="7 7 17 7 17 17"/></svg>
             </span>
           </div>
         </a>


### PR DESCRIPTION
## What

Follow-up to #22. The Modern Agents deep-dive deck is hosted externally, not on the site, so this updates the Resources deck card to link to **https://aka.ms/CopilotStudioDeepDiveDeck** (opens in a new tab) instead of downloading a locally hosted file.

## Changes
- Deck card `href` → `https://aka.ms/CopilotStudioDeepDiveDeck`, `target="_blank" rel="noopener"`, link label "Open the deck".
- Removed the placeholder `public/files/modern-agents-deep-dive.pptx`.

## Verification
- `npm run build` passes; verified locally via `astro dev`.