### PR TITLE
Add deck issue template and scope site/sample feedback form

### DIFF
--- a/.github/ISSUE_TEMPLATE/deck-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/deck-feedback.yml
@@ -1,0 +1,36 @@
+name: Deck issue or feedback
+description: Report an issue or share feedback about the Modern Agents technical deep-dive deck
+title: "[Deck] "
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for the **Modern Agents technical deep-dive deck** ([aka.ms/CopilotStudioDeepDiveDeck](https://aka.ms/CopilotStudioDeepDiveDeck)).
+        For the walkthrough mini-site or the sample solution, use the **Site or sample issue / feedback** form instead.
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of report is this?
+      options:
+        - Error or inaccuracy
+        - Suggestion or improvement
+        - Broken or outdated content
+        - Question
+    validations:
+      required: true
+  - type: input
+    id: slide
+    attributes:
+      label: Slide or section
+      description: Which slide number or section does this relate to (if applicable)?
+      placeholder: e.g. Slide 12, "Connected agents"
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Describe the issue or feedback. For errors, tell us what's wrong and what it should say.
+      placeholder: Your feedback here...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,15 +1,31 @@
-name: Feedback
-description: Share feedback about the ETC sample or guide
-title: "[Feedback] "
+name: Site or sample issue or feedback
+description: Report a bug or share feedback about the mini-site or the sample solution
+title: "[Site/Sample] "
 labels: ["feedback"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for the **walkthrough mini-site** or the **sample solution** (import, agents, MCP tools).
+        For the Modern Agents technical deep-dive deck, use the **Deck issue or feedback** form instead.
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of report is this?
+      options:
+        - Bug or something is broken
+        - Feedback or suggestion
+        - Question
+    validations:
+      required: true
   - type: dropdown
     id: area
     attributes:
       label: Area
-      description: What does your feedback relate to?
+      description: What does this relate to?
       options:
-        - Scenario walkthrough (minisite)
+        - Scenario walkthrough (mini-site)
         - Chat UI
         - Solution import / deployment
         - Connector / MCP tools
@@ -18,10 +34,16 @@ body:
     validations:
       required: true
   - type: textarea
-    id: feedback
+    id: details
     attributes:
-      label: Feedback
-      description: Tell us what you think, what worked, what didn't, or what you'd like to see improved.
+      label: Details
+      description: Describe the issue or feedback. For bugs, include steps to reproduce, what you expected, and what actually happened.
       placeholder: Your feedback here...
     validations:
       required: true
+  - type: input
+    id: url
+    attributes:
+      label: Page URL (optional)
+      description: If this relates to a specific page on the mini-site, paste the URL.
+      placeholder: https://microsoft.github.io/new-copilot-studio-tech-guide/...


### PR DESCRIPTION
Adds two issue forms so contributors can report problems or give feedback on the right thing:

- **Deck issue or feedback** (new `deck-feedback.yml`) — for the Modern Agents technical deep-dive deck, with Type, slide/section, and details fields.
- **Site or sample issue or feedback** (existing `feedback.yml`, refined) — scoped to the mini-site and sample solution; adds a Type field and an optional page URL.

The two forms cross-reference each other. Both validated as YAML.