### PR TITLE
Clarify CTA setup copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -199,7 +199,7 @@ const base = import.meta.env.BASE_URL;
         <div class="cta__text">
           <p class="section-label">Get started</p>
           <h2>Stand up the store</h2>
-          <p class="cta__desc">Import the solution, create the MCP connections, add the policy knowledge, publish the agents, then run the scripted prompts. Everything runs inside Power Platform. No servers, no code to host.</p>
+          <p class="cta__desc">Import the solution, create the MCP connections, add the policy documents, publish the agents, then run the scripted prompts. Everything runs inside Power Platform. No servers, no code to host.</p>
           <div class="cta__actions">
             <a href="https://github.com/microsoft/new-copilot-studio-tech-guide/tree/main/sample/solution" class="btn btn--primary">
               Get the sample


### PR DESCRIPTION
Changes "add the policy knowledge" to "add the policy documents" in the Get started CTA — the step is uploading the store policy documents as a knowledge source, and the original phrasing read awkwardly.