### PR TITLE
Simplify pillars intro copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,7 +79,7 @@ const base = import.meta.env.BASE_URL;
     <div class="container">
       <p class="section-label">What it shows</p>
       <h2>The building blocks of the new agent experience</h2>
-      <p class="pillars__intro">Every scenario composes the same primitives of the Copilot Studio Modern Agent Experience. The more advanced scenarios simply orchestrate more of them at once.</p>
+      <p class="pillars__intro">Every scenario is built from the same core capabilities of the Copilot Studio modern agent experience. The more advanced scenarios simply bring more of them together at once.</p>
 
       <div class="pillars__grid">
         <div class="pillar">


### PR DESCRIPTION
Reword the pillars intro to drop jargon ("primitives", "orchestrate") in favor of plain language.