### PR TITLE
Add ZoomIt DemoType copy controls to scenario pages

### DIFF
--- a/src/components/DemoTypeCopy.astro
+++ b/src/components/DemoTypeCopy.astro
@@ -34,9 +34,9 @@
         return;
       }
 
-      const demoTypeScript = prompts
+      const demoTypeScript = `[start]${prompts
         .map((prompt) => `${prompt}[enter][end]`)
-        .join('');
+        .join('')}`;
 
       window.clearTimeout(resetTimer);
       button.classList.remove('copied', 'copy-failed');

--- a/src/components/DemoTypeCopy.astro
+++ b/src/components/DemoTypeCopy.astro
@@ -1,0 +1,59 @@
+<button
+  class="demotype-copy"
+  type="button"
+  data-demotype-copy
+  title="Copy all scenario prompts as a ZoomIt DemoType script"
+>
+  <span class="demotype-copy__icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
+  </span>
+  <span class="demotype-copy__text">
+    <span class="demotype-copy__label" data-demotype-label aria-live="polite">Copy DemoType</span>
+    <span class="demotype-copy__hint">All prompts &middot; ZoomIt</span>
+  </span>
+</button>
+
+<script>
+  const demoTypeButtons = document.querySelectorAll<HTMLButtonElement>('[data-demotype-copy]');
+
+  demoTypeButtons.forEach((button) => {
+    const label = button.querySelector<HTMLElement>('[data-demotype-label]');
+    let resetTimer: number | undefined;
+
+    button.addEventListener('click', async () => {
+      const prompts = Array.from(document.querySelectorAll<HTMLElement>('.try-prompt__text'))
+        .map((prompt) => prompt.textContent?.trim())
+        .filter((text): text is string => Boolean(text));
+
+      if (prompts.length === 0) {
+        if (label) label.textContent = 'No prompts found';
+        button.classList.add('copy-failed');
+        return;
+      }
+
+      const demoTypeScript = prompts
+        .map((prompt) => `${prompt}[enter][end]`)
+        .join('');
+
+      window.clearTimeout(resetTimer);
+      button.classList.remove('copied', 'copy-failed');
+
+      try {
+        await navigator.clipboard.writeText(demoTypeScript);
+        if (label) label.textContent = 'DemoType copied';
+        button.classList.add('copied');
+      } catch {
+        if (label) label.textContent = 'Copy failed';
+        button.classList.add('copy-failed');
+      }
+
+      resetTimer = window.setTimeout(() => {
+        if (label) label.textContent = 'Copy DemoType';
+        button.classList.remove('copied', 'copy-failed');
+      }, 2000);
+    });
+  });
+</script>

--- a/src/pages/scenarios/block-party-trade-up.astro
+++ b/src/pages/scenarios/block-party-trade-up.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../../layouts/Base.astro';
+import DemoTypeCopy from '../../components/DemoTypeCopy.astro';
 import '../../styles/scenario.css';
 
 const base = import.meta.env.BASE_URL;
@@ -20,12 +21,15 @@ const base = import.meta.env.BASE_URL;
           The associate turns to the <strong>Store Associate Assistant</strong> to untangle all
           of it in a single conversation.
         </p>
-        <div class="scenario__agent" style="--accent: var(--c-purple);">
-          <span class="scenario__agent-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8.01" y2="16"/><line x1="16" y1="16" x2="16.01" y2="16"/></svg></span>
-          <span class="scenario__agent-text">
-            <span class="scenario__agent-label">Test this scenario with</span>
-            <span class="scenario__agent-name">Store Associate Assistant</span>
-          </span>
+        <div class="scenario__tools">
+          <div class="scenario__agent" style="--accent: var(--c-purple);">
+            <span class="scenario__agent-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8.01" y2="16"/><line x1="16" y1="16" x2="16.01" y2="16"/></svg></span>
+            <span class="scenario__agent-text">
+              <span class="scenario__agent-label">Test this scenario with</span>
+              <span class="scenario__agent-name">Store Associate Assistant</span>
+            </span>
+          </div>
+          <DemoTypeCopy />
         </div>
       </header>
 

--- a/src/pages/scenarios/markdown-review.astro
+++ b/src/pages/scenarios/markdown-review.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../../layouts/Base.astro';
+import DemoTypeCopy from '../../components/DemoTypeCopy.astro';
 import '../../styles/scenario.css';
 
 const base = import.meta.env.BASE_URL;
@@ -20,12 +21,15 @@ const base = import.meta.env.BASE_URL;
           from a store-wide view and drilling all the way down to a single SKU, week by week, then
           to a discount she can actually defend.
         </p>
-        <div class="scenario__agent" style="--accent: var(--c-orange);">
-          <span class="scenario__agent-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8.01" y2="16"/><line x1="16" y1="16" x2="16.01" y2="16"/></svg></span>
-          <span class="scenario__agent-text">
-            <span class="scenario__agent-label">Test this scenario with</span>
-            <span class="scenario__agent-name">Merch Insights Assistant</span>
-          </span>
+        <div class="scenario__tools">
+          <div class="scenario__agent" style="--accent: var(--c-orange);">
+            <span class="scenario__agent-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8.01" y2="16"/><line x1="16" y1="16" x2="16.01" y2="16"/></svg></span>
+            <span class="scenario__agent-text">
+              <span class="scenario__agent-label">Test this scenario with</span>
+              <span class="scenario__agent-name">Merch Insights Assistant</span>
+            </span>
+          </div>
+          <DemoTypeCopy />
         </div>
       </header>
 

--- a/src/pages/scenarios/self-serve-card-reissue.astro
+++ b/src/pages/scenarios/self-serve-card-reissue.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../../layouts/Base.astro';
+import DemoTypeCopy from '../../components/DemoTypeCopy.astro';
 import '../../styles/scenario.css';
 
 const base = import.meta.env.BASE_URL;
@@ -19,12 +20,15 @@ const base = import.meta.env.BASE_URL;
           and one firm rule underneath it all: nothing on the account changes until the member
           proves the card is really theirs.
         </p>
-        <div class="scenario__agent" style="--accent: var(--c-green);">
-          <span class="scenario__agent-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8.01" y2="16"/><line x1="16" y1="16" x2="16.01" y2="16"/></svg></span>
-          <span class="scenario__agent-text">
-            <span class="scenario__agent-label">Test this scenario with</span>
-            <span class="scenario__agent-name">Returns &amp; Service Assistant</span>
-          </span>
+        <div class="scenario__tools">
+          <div class="scenario__agent" style="--accent: var(--c-green);">
+            <span class="scenario__agent-icon"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8.01" y2="16"/><line x1="16" y1="16" x2="16.01" y2="16"/></svg></span>
+            <span class="scenario__agent-text">
+              <span class="scenario__agent-label">Test this scenario with</span>
+              <span class="scenario__agent-name">Returns &amp; Service Assistant</span>
+            </span>
+          </div>
+          <DemoTypeCopy />
         </div>
       </header>
 

--- a/src/styles/scenario.css
+++ b/src/styles/scenario.css
@@ -2,17 +2,27 @@
 .scenario { padding: var(--space-3xl) 0; }
 .back { display: inline-flex; align-items: center; gap: 4px; font-size: 0.85rem; font-weight: 600; color: var(--c-text-muted); margin-bottom: var(--space-xl); }
 .back:hover { color: var(--c-primary); }
-.scenario__header { max-width: 720px; }
-.scenario__header h1 { margin-top: var(--space-md); font-family: var(--font-display); letter-spacing: 0.01em; }
-.scenario__lead { margin-top: var(--space-lg); font-size: 1.05rem; color: var(--c-text-secondary); line-height: 1.7; }
+.scenario__header h1 { max-width: 720px; margin-top: var(--space-md); font-family: var(--font-display); letter-spacing: 0.01em; }
+.scenario__lead { max-width: 720px; margin-top: var(--space-lg); font-size: 1.05rem; color: var(--c-text-secondary); line-height: 1.7; }
 .scenario__cast { display: flex; flex-wrap: wrap; gap: 7px; margin-top: var(--space-lg); }
 .scenario__cast .pill { font-family: var(--font-mono); font-size: 0.68rem; font-weight: 600; color: var(--c-text-secondary); background: var(--c-surface); border: 1px solid var(--c-border-subtle); padding: 4px 9px; border-radius: 6px; }
-.scenario__agent { --accent: var(--c-primary); display: flex; align-items: center; gap: 14px; margin-top: var(--space-xl); padding: var(--space-md) var(--space-lg); border: 1px solid var(--c-border-subtle); border-radius: var(--radius-md); background: var(--c-surface); }
+.scenario__tools { display: grid; grid-template-columns: minmax(0, 720px) minmax(190px, 220px); align-items: stretch; gap: var(--space-md); margin-top: var(--space-xl); }
+.scenario__agent { --accent: var(--c-primary); display: flex; align-items: center; gap: 14px; padding: var(--space-md) var(--space-lg); border: 1px solid var(--c-border-subtle); border-radius: var(--radius-md); background: var(--c-surface); }
 .scenario__agent-icon { flex-shrink: 0; display: inline-flex; color: var(--accent); }
 .scenario__agent-icon svg { width: 24px; height: 24px; }
 .scenario__agent-text { display: flex; flex-direction: column; gap: 2px; }
 .scenario__agent-label { font-family: var(--font-mono); font-size: 0.7rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--c-text-muted); }
 .scenario__agent-name { font-size: 1.05rem; font-weight: 700; color: var(--c-text); font-family: var(--font-display); letter-spacing: -0.01em; line-height: 1.2; }
+.demotype-copy { display: flex; align-items: center; gap: 12px; min-width: 0; padding: var(--space-md) var(--space-lg); color: var(--c-text); text-align: left; background: var(--c-surface); border: 1px solid var(--c-border-subtle); border-radius: var(--radius-md); cursor: pointer; transition: color 0.15s ease, border-color 0.15s ease, transform 0.15s ease; }
+.demotype-copy:hover { color: var(--c-primary); border-color: var(--c-primary); transform: translateY(-1px); }
+.demotype-copy:focus-visible { outline: 2px solid var(--c-primary); outline-offset: 2px; }
+.demotype-copy.copied { color: var(--c-green); border-color: var(--c-green); }
+.demotype-copy.copy-failed { color: var(--c-red); border-color: var(--c-red); }
+.demotype-copy__icon { display: inline-flex; flex-shrink: 0; }
+.demotype-copy__icon svg { width: 22px; height: 22px; }
+.demotype-copy__text { display: flex; min-width: 0; flex-direction: column; gap: 1px; }
+.demotype-copy__label { font-family: var(--font-display); font-size: 0.9rem; font-weight: 700; line-height: 1.25; white-space: nowrap; }
+.demotype-copy__hint { font-family: var(--font-mono); font-size: 0.62rem; color: var(--c-text-muted); white-space: nowrap; }
 .scenario__section { margin-top: var(--space-3xl); }
 .scenario__section h2 { margin-bottom: var(--space-lg); }
 
@@ -106,4 +116,9 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--c-purple);
+}
+
+@media (max-width: 800px) {
+  .scenario__tools { grid-template-columns: 1fr; }
+  .demotype-copy { width: 100%; }
 }


### PR DESCRIPTION
Scenario presenters currently have to copy prompts individually and convert them to ZoomIt syntax before a demo. This adds a compact, non-invasive copy control beside the agent card on every scenario page.

The reusable control derives its payload from the prompts already rendered on the page, so the DemoType script cannot drift from the documented conversation. The script starts with `[start]`, and each prompt is emitted as a separate `prompt[enter][end]` snippet, with responsive styling and visible success or failure feedback.

## Validation

- `npm run build`
- Verified desktop and mobile layouts
- Verified the clipboard payload and copied-state feedback in a browser