### PR TITLE
deploy: only quote Windows args that need it (fixes #20)

### DIFF
--- a/deploy/deploy.mjs
+++ b/deploy/deploy.mjs
@@ -113,7 +113,17 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // ---------- shell ----------
 function quoteArg(a) {
   a = String(a);
-  return isWin ? '"' + a.replace(/"/g, '""') + '"' : "'" + a.replace(/'/g, `'\\''`) + "'";
+  if (isWin) {
+    // Only quote when the token actually needs it. pac v2.x treats surrounding
+    // quotes as part of the token and rejects quote-wrapped subcommands (printing
+    // its help banner and exiting 0), so blanket-quoting every arg breaks e.g.
+    // `pac auth list`. Pass plain tokens (subcommands, flags, GUIDs, URLs) through
+    // unquoted; wrap only args containing whitespace or cmd.exe metacharacters.
+    if (a === '') return '""';
+    if (!/[\s"&|<>^()]/.test(a)) return a;
+    return '"' + a.replace(/"/g, '""') + '"';
+  }
+  return "'" + a.replace(/'/g, `'\\''`) + "'";
 }
 // Run a command (cross-OS via shell). Returns { code, stdout, stderr, out, timedOut }.
 // opts.timeoutMs: kill the child after this many ms (pac can hang for 30+ min on


### PR DESCRIPTION
## Summary

Fixes #20.

On native Windows, `deploy/deploy.mjs` failed immediately with `[error] no pac auth profiles found. Run: pac auth create` even when `pac auth list` showed authenticated profiles.

## Root cause

`quoteArg()` unconditionally wrapped **every** argument in double quotes on Windows, so `sh('pac', ['auth', 'list'])` ran as `pac "auth" "list"`. pac v2.x treats the surrounding quotes as part of the token, rejects the quote-wrapped subcommand, prints its help banner, and **exits 0**. Because the exit code is 0, `parsePacAuthList()` proceeds, finds zero `[n]` rows in the banner output, and dies with `no pac auth profiles found` — blocking every native-Windows user at the first deploy step. macOS/Linux/WSL were unaffected because the POSIX single-quoting branch is stripped correctly by POSIX shells.

## Fix

On Windows, quote only args that actually need it (whitespace or cmd.exe metacharacters `[\s"&|<>^()]`); pass plain tokens (subcommands, flags, GUIDs, URLs) through unquoted. Empty args become `""`. The POSIX branch is unchanged.

## Verification

- `node --check deploy/deploy.mjs` passes.
- Behavioral test confirms Windows now emits `auth`, `list`, `--index`, GUIDs and URLs unquoted, while args with spaces/metacharacters (`a b`, `c:\path with space\x.zip`, `x&y`) are still correctly quoted. POSIX output is unchanged.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>