### PR TITLE
Align site copy with Copilot Studio naming guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/deck-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/deck-feedback.yml
@@ -1,12 +1,12 @@
 name: Deck issue or feedback
-description: Report an issue or share feedback about the Modern Agents technical deep-dive deck
+description: Report an issue or share feedback about the Copilot Studio technical deep-dive deck
 title: "[Copilot Studio Deepdive Deck] "
 labels: ["feedback"]
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form for the **Modern Agents technical deep-dive deck** ([aka.ms/CopilotStudioDeepDiveDeck](https://aka.ms/CopilotStudioDeepDiveDeck)).
+        Use this form for the **Copilot Studio technical deep-dive deck** ([aka.ms/CopilotStudioDeepDiveDeck](https://aka.ms/CopilotStudioDeepDiveDeck)).
         For the walkthrough mini-site or the sample solution, use the **Site or sample issue / feedback** form instead.
   - type: dropdown
     id: type

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Use this form for the **walkthrough mini-site** or the **sample solution** (import, agents, MCP tools).
-        For the Modern Agents technical deep-dive deck, use the **Deck issue or feedback** form instead.
+        For the Copilot Studio technical deep-dive deck, use the **Deck issue or feedback** form instead.
   - type: dropdown
     id: type
     attributes:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Copilot Studio Technical Guide
 
-A showcase site and deployable sample for the new Agents and Workflows experience in Microsoft Copilot Studio.
+A showcase site and deployable sample for the Agents and Workflows experience in Microsoft Copilot Studio.
 
 **Live site**: https://microsoft.github.io/new-copilot-studio-tech-guide/
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -6,7 +6,7 @@ interface Props {
   description?: string;
 }
 
-const { title, description = 'A technical guide to the new AI workloads in Copilot Studio Agents and Workflows' } = Astro.props;
+const { title, description = 'A technical guide to AI workloads in Copilot Studio Agents and Workflows' } = Astro.props;
 const base = import.meta.env.BASE_URL;
 const repo = 'https://github.com/microsoft/new-copilot-studio-tech-guide';
 
@@ -126,7 +126,7 @@ const enableClarity = import.meta.env.PROD;
     <footer class="footer">
       <div class="container">
         <div class="footer__inner">
-          <p>A mock demo store for the Copilot Studio <strong>Modern Agent Experience</strong>. All products, members, and policies are fictional. Built by the <a href="https://microsoft.github.io/mcscatblog/">Copilot Studio CAT</a> team &middot; MIT licensed. <span class="footer__sep">&middot;</span> <a href={`${repo}/issues/new?template=feedback.yml`} class="footer__feedback"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg> Send feedback</a></p>
+          <p>A mock demo store for Copilot Studio <strong>agents</strong>. All products, members, and policies are fictional. Built by the <a href="https://microsoft.github.io/mcscatblog/">Copilot Studio CAT</a> team &middot; MIT licensed. <span class="footer__sep">&middot;</span> <a href={`${repo}/issues/new?template=feedback.yml`} class="footer__feedback"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg> Send feedback</a></p>
         </div>
       </div>
     </footer>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,34 +12,38 @@ const base = import.meta.env.BASE_URL;
       <div class="hero__content">
         <div class="hero__eyebrow">
           <span class="hero__eyebrow-dot">&#9670;</span>
-          Copilot Studio &middot; Modern Experience
+          Copilot Studio
         </div>
         <h1 class="hero__title">
-          <span class="t-cat">The new <span class="hero__title-accent">Copilot Studio</span> experience</span>
+          <span class="t-cat">The <span class="hero__title-accent">Copilot Studio</span> experience</span>
           <span class="t-bb">BlastBox <span class="hero__title-omega">Omega</span></span>
         </h1>
         <p class="hero__tagline">
-          <span class="t-cat">A hands-on guide to the new Agents and Workflows in Copilot Studio.</span>
+          <span class="t-cat">A hands-on guide to Agents and Workflows in Copilot Studio.</span>
           <span class="t-bb">The retro-future game store, run by agents.</span>
         </p>
         <p class="hero__subtitle">
           <span class="t-cat">
             Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
-            moving from a single chatbot to coordinated, multi-agent systems. This is a
+            moving from a single chatbot to coordinated, multi-agent systems on the
+            <strong>GitHub Copilot harness</strong> &mdash; its agentic build, where the
+            agent reasons, acts, and adapts in a continuous loop. This is a
             <strong>technical guide from the CAT team</strong> on building enterprise-grade
-            scenarios on that new foundation: practical patterns for <strong>connected
+            scenarios on that foundation: practical patterns for <strong>connected
             agents</strong>, <strong>MCP servers</strong>, <strong>runtime skills</strong>,
             and <strong>generated files</strong>, each one backed by a complete, runnable
             reference you can deploy and inspect.
           </span>
           <span class="t-bb">
             Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
-            moving from a single chatbot to coordinated, multi-agent systems. BlastBox Omega is a
+            moving from a single chatbot to coordinated, multi-agent systems on the
+            <strong>GitHub Copilot harness</strong> &mdash; its agentic build, where the
+            agent reasons, acts, and adapts in a continuous loop. BlastBox Omega is a
             complete, runnable reference: a parent agent that delegates to <strong>connected
             agents</strong>, calls <strong>multiple MCP servers</strong>, runs
             <strong>per-agent skills</strong> that generate and execute Python at runtime, and
             returns real <strong>generated files</strong>. End-to-end reference scenarios
-            spanning <strong>agents and workflows</strong> in the new Copilot Studio.
+            spanning <strong>agents and workflows</strong> in Copilot Studio.
           </span>
         </p>
         <div class="hero__actions">
@@ -78,8 +82,8 @@ const base = import.meta.env.BASE_URL;
   <section class="pillars">
     <div class="container">
       <p class="section-label">What it shows</p>
-      <h2>The building blocks of the new agent experience</h2>
-      <p class="pillars__intro">Every scenario is built from the same core capabilities of the Copilot Studio modern agent experience. The more advanced scenarios simply bring more of them together at once.</p>
+      <h2>The building blocks of the agent experience</h2>
+      <p class="pillars__intro">Every scenario is built from the same core capabilities of the Copilot Studio agent experience. The more advanced scenarios simply bring more of them together at once.</p>
 
       <div class="pillars__grid">
         <div class="pillar">
@@ -88,7 +92,7 @@ const base = import.meta.env.BASE_URL;
             <span class="ticon-bb" style="font-size:1.4rem;">&#129309;</span>
           </div>
           <h3>Connected agents</h3>
-          <p>A parent orchestrator delegates to specialist child agents and weaves their answers back into a single conversation.</p>
+          <p>A parent agent delegates to specialist child agents and weaves their answers back into a single conversation.</p>
         </div>
         <div class="pillar">
           <div class="pillar__icon" style="--g: var(--c-purple);">
@@ -226,7 +230,7 @@ const base = import.meta.env.BASE_URL;
     <div class="container">
       <p class="section-label">Go deeper</p>
       <h2>Resources</h2>
-      <p class="resources__intro">Reference material to help you understand and extend the new Copilot Studio agent experience, a technical deep dive on modern agents and the open-source plugin that ties into it.</p>
+      <p class="resources__intro">Reference material to help you understand and extend agents in Copilot Studio, a technical deep dive on agents and the open-source plugin that ties into it.</p>
 
       <div class="resources__grid">
         <div class="resource resource--deck" style="--accent: var(--c-purple);">
@@ -236,8 +240,8 @@ const base = import.meta.env.BASE_URL;
             </span>
             <span class="resource__kind">Deck &middot; PPTX</span>
           </div>
-          <h3 class="resource__title">Modern Agents technical deep dive</h3>
-          <p class="resource__desc">A slide-by-slide walkthrough of the architecture behind the new Copilot Studio agents, connected agents, MCP, skills, orchestration, and file generation.</p>
+          <h3 class="resource__title">Copilot Studio technical deep dive</h3>
+          <p class="resource__desc">A slide-by-slide walkthrough of the architecture behind Copilot Studio agents, connected agents, MCP, skills, orchestration, and file generation.</p>
           <div class="resource__actions">
             <a href="https://aka.ms/CopilotStudioDeepDiveDeck" class="resource__link resource__link--stretch" target="_blank" rel="noopener">
               Open the deck
@@ -258,7 +262,7 @@ const base = import.meta.env.BASE_URL;
             <span class="resource__kind">Repo &middot; GitHub</span>
           </div>
           <h3 class="resource__title">Copilot Studio Plugin</h3>
-          <p class="resource__desc">An open-source plugin for AI coding agents that migrates classic Copilot Studio agents to the modern experience, or builds brand-new modern agents from scratch.</p>
+          <p class="resource__desc">An open-source plugin for AI coding agents that upgrades existing Copilot Studio agents to the GitHub Copilot harness, or builds new agents from scratch.</p>
           <span class="resource__link">
             View on GitHub
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><polyline points="7 7 17 7 17 17"/></svg>

--- a/src/pages/scenarios/block-party-trade-up.astro
+++ b/src/pages/scenarios/block-party-trade-up.astro
@@ -51,7 +51,7 @@ const base = import.meta.env.BASE_URL;
             <div class="tl-content">
               <div class="tl-label">Agent &rarr; connected agents &rarr; Associate</div>
               <div class="tl-steps">
-                <p>The orchestrator fans out and front-loads the whole picture in a single pass, rather than asking one question at a time.</p>
+                <p>The agent fans out and front-loads the whole picture in a single pass, rather than asking one question at a time.</p>
                 <div class="tl-tool"><span class="tl-tool-name">get_membership</span> reads MEGA-BLAST-1024 (Plus Extra, 8 months unused, $10 fee)</div>
                 <div class="tl-tool"><span class="tl-tool-name">Store Policy Agent &middot; search_policy</span> "defective console warranty vs accidental damage" &rarr; returns a <em>question</em>, not a ruling (its rule is to establish the defect cause first)</div>
                 <div class="tl-tool"><span class="tl-tool-name">Order Management MCP &middot; search_orders</span> finds nothing under the member ID, so it retries <strong>by customer name</strong> (Jordan Pixel) and gets a hit</div>


### PR DESCRIPTION
## What & why

Reviewed the site + repo docs against the Copilot Studio naming guide and applied the high-confidence fixes. The theme: **one Copilot Studio**, retire filler "new/modern", let the **agent** be the actor (not the "orchestrator"), and introduce the **GitHub Copilot harness** once, framed as a *build*.

## Changes

**Hero (`index.astro`)**
- Eyebrow/title/tagline: drop "Modern Experience" / "The **new** Copilot Studio experience" → "The Copilot Studio experience"
- Both skins' subtitles now name the **GitHub Copilot harness** ("its agentic build, where the agent reasons, acts, and adapts in a continuous loop")
- "that **new** foundation" → "that foundation"

**Pillars**
- "the **new/modern** agent experience" → "the agent experience"
- Connected agents: "A parent **orchestrator** delegates…" → "A parent **agent** delegates…"

**Resources**
- Deck: "**Modern Agents** technical deep dive" → "**Copilot Studio** technical deep dive"
- Plugin: "**migrates classic** … to the **modern experience** … brand-new **modern agents**" → "**upgrades** existing … to the **GitHub Copilot harness** … builds new agents"

**Other**
- `Base.astro` footer ("Modern Agent Experience" → "agents") + meta description
- `README.md` tagline
- Issue templates (`deck-feedback.yml`, `feedback.yml`): deck name updated to match
- `block-party-trade-up.astro`: "orchestrator" → "agent"

## Notes
- Production build passes (`npm run build`, 4 pages).
- Deliberately **not** included (lower-confidence / needs a call): `deploy/README.md` "modern picker" wording, connector `.csx` comments, video-overlay scripts, `sample/solution/README.md` env-toggle name, and the archived `sample/archive/**` batch.