### PR TITLE
Refocus home on the runnable sample: one-liner install, FAQ page, design polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,33 @@ Four agents (flagship Store Associate Assistant, self-serve Returns & Service As
 and two connected agents) and four inline MCP connectors (Membership, Order Management,
 Policy RAG, Warehouse). Everything runs inside the Power Platform: no external servers.
 
-Stand it up with one cross-platform script (needs **Node 18+**, **pac CLI**, and **az
+Stand it up with one command — no clone required. It downloads the deploy assets and
+runs the guided deploy (needs **Node 18+**, the **pac CLI** signed in, and the **az
 CLI** installed):
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex
+```
+
+It imports both solutions, deploys the connector code, creates the connections, and
+publishes the agents, then prints one ~2-minute manual UI step. Set `BLASTBOX_REF` to
+deploy from a branch or tag other than `main`.
+
+Prefer to clone? Everything the script needs is committed in the repo:
 
 ```bash
 pac auth create                   # once: sign pac in to the target tenant
 node deploy/deploy.mjs            # guided: pick profile, pick env, deploy
 node deploy/deploy.mjs --help     # all options
 ```
-
-It imports both solutions, deploys the connector code, creates the connections, and
-publishes the agents, then prints one ~2-minute manual UI step.
 
 ```
 deploy/             Scripted, repeatable deploy (deploy.mjs + README)

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ CLI** installed):
 **macOS / Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.sh | BLASTBOX_REF=sample-first-installer bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"
+powershell -c "$env:BLASTBOX_REF='sample-first-installer'; irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.ps1 | iex"
 ```
 
 It imports both solutions, deploys the connector code, creates the connections, and

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ CLI** installed):
 **macOS / Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.sh | BLASTBOX_REF=sample-first-installer bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-powershell -c "$env:BLASTBOX_REF='sample-first-installer'; irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"
 ```
 
 It imports both solutions, deploys the connector code, creates the connections, and

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-g
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex
+powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"
 ```
 
 It imports both solutions, deploys the connector code, creates the connections, and

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,13 +18,13 @@ solution zips and all connector code) and starts the same guided deploy:
 **macOS / Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.sh | BLASTBOX_REF=sample-first-installer bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"
+powershell -c "$env:BLASTBOX_REF='sample-first-installer'; irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.ps1 | iex"
 ```
 
 Set the `BLASTBOX_REF` env var to deploy from a branch or tag other than `main`. You

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,13 +18,13 @@ solution zips and all connector code) and starts the same guided deploy:
 **macOS / Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.sh | BLASTBOX_REF=sample-first-installer bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-powershell -c "$env:BLASTBOX_REF='sample-first-installer'; irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"
 ```
 
 Set the `BLASTBOX_REF` env var to deploy from a branch or tag other than `main`. You

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,7 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-g
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex
+powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"
 ```
 
 Set the `BLASTBOX_REF` env var to deploy from a branch or tag other than `main`. You

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,6 +10,31 @@ Run it from a fresh clone — everything it needs (both solution zips and all
 connector code) is in the repo. It does **not** create or delete environments; you
 point it at an env you already have.
 
+## Quickest path — one command, no clone
+
+Deploy the sample without cloning anything. This downloads the deploy assets (both
+solution zips and all connector code) and starts the same guided deploy:
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex
+```
+
+Set the `BLASTBOX_REF` env var to deploy from a branch or tag other than `main`. You
+still need the [requirements](#requirements) below — Node 18+, the pac CLI signed in,
+and the az CLI.
+
+### Prefer to clone?
+
+Everything the script needs is committed in the repo, so a clone works too:
+
 ```bash
 node deploy/deploy.mjs            # guided: pick profile, pick env, deploy
 node deploy/deploy.mjs --help     # all options
@@ -27,7 +52,9 @@ arrays (no shell string interpolation), resolves paths with `node:path`, and rea
    pac auth create            # then verify with: pac auth list
    ```
 
-2. **Deploy** (guided — it lists your profiles and envs):
+2. **Deploy** (guided — it lists your profiles and envs). Run the no-clone one-liner
+   from the [Quickest path](#quickest-path--one-command-no-clone) above, or from a
+   clone:
 
    ```bash
    node deploy/deploy.mjs

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -1,0 +1,61 @@
+<#
+  install.ps1 - no-clone bootstrap for the BlastBox Omega sample (Windows).
+
+  Downloads the deploy assets straight from GitHub and runs the guided
+  deploy (deploy/deploy.mjs). Nothing is left behind except the solutions
+  and connectors it imports into your Power Platform environment.
+
+    irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex
+
+  Set $env:BLASTBOX_REF to deploy from a specific branch or tag (default: main).
+#>
+#requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+
+$repo = 'microsoft/new-copilot-studio-tech-guide'
+$ref  = if ($env:BLASTBOX_REF) { $env:BLASTBOX_REF } else { 'main' }
+
+function Info($m) { Write-Host "==> $m" -ForegroundColor Cyan }
+function Warn($m) { Write-Host "WARNING: $m" -ForegroundColor Yellow }
+
+# --- preflight ---------------------------------------------------------------
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  throw 'Node.js 18+ is required but was not found. Install it from https://nodejs.org and re-run.'
+}
+$nodeMajor = [int](node -p "process.versions.node.split('.')[0]")
+if ($nodeMajor -lt 18) { throw "Node.js 18+ is required (found $(node -v))." }
+if (-not (Get-Command pac -ErrorAction SilentlyContinue)) {
+  Warn 'pac CLI not found on PATH. The deploy needs it signed in (pac auth create). See deploy/README.md.'
+}
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+  Warn 'az CLI not found on PATH. The deploy uses it for the connection REST calls. See deploy/README.md.'
+}
+
+# --- download ----------------------------------------------------------------
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("blastbox-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp | Out-Null
+try {
+  $zip = Join-Path $tmp 'src.zip'
+  Info "Downloading the sample ($repo@$ref)..."
+  Invoke-WebRequest -Uri "https://codeload.github.com/$repo/zip/refs/heads/$ref" -OutFile $zip -UseBasicParsing
+
+  Info 'Extracting the deploy assets...'
+  Expand-Archive -Path $zip -DestinationPath $tmp -Force
+  $root = Join-Path $tmp "new-copilot-studio-tech-guide-$ref"
+  if (-not (Test-Path (Join-Path $root 'deploy\deploy.mjs'))) {
+    throw 'deploy/deploy.mjs is missing after extract.'
+  }
+
+  # --- run -------------------------------------------------------------------
+  # deploy.mjs is interactive; running under 'irm | iex' inherits the console
+  # so its prompts work without any redirection.
+  Push-Location $root
+  try {
+    Info 'Starting the guided deploy...'
+    & node 'deploy/deploy.mjs' @args
+  }
+  finally { Pop-Location }
+}
+finally {
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# install.sh — no-clone bootstrap for the BlastBox Omega sample.
+#
+# Downloads the deploy assets straight from GitHub and runs the guided
+# deploy (deploy/deploy.mjs). Nothing is left behind except the solutions
+# and connectors it imports into your Power Platform environment.
+#
+#   curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash
+#
+# Set BLASTBOX_REF to deploy from a specific branch or tag (default: main).
+#
+set -euo pipefail
+
+REPO="microsoft/new-copilot-studio-tech-guide"
+REF="${BLASTBOX_REF:-main}"
+
+say()  { printf '==> %s\n' "$*"; }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# --- preflight ---------------------------------------------------------------
+command -v node >/dev/null 2>&1 || die "Node.js 18+ is required but was not found. Install it from https://nodejs.org and re-run."
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+[ "${NODE_MAJOR:-0}" -ge 18 ] || die "Node.js 18+ is required (found $(node -v 2>/dev/null || echo 'unknown'))."
+command -v curl >/dev/null 2>&1 || die "curl is required but was not found."
+command -v tar  >/dev/null 2>&1 || die "tar is required but was not found."
+command -v pac  >/dev/null 2>&1 || warn "pac CLI not found on PATH. The deploy needs it signed in (pac auth create). See deploy/README.md."
+command -v az   >/dev/null 2>&1 || warn "az CLI not found on PATH. The deploy uses it for the connection REST calls. See deploy/README.md."
+
+# --- download ----------------------------------------------------------------
+TMP="$(mktemp -d 2>/dev/null || mktemp -d -t blastbox)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+say "Downloading the sample (${REPO}@${REF})..."
+curl -fsSL "https://codeload.github.com/${REPO}/tar.gz/refs/heads/${REF}" -o "$TMP/src.tgz" \
+  || die "Download failed. Check your network, or set BLASTBOX_REF to a valid branch or tag."
+
+say "Extracting the deploy assets..."
+tar -xzf "$TMP/src.tgz" -C "$TMP" --strip-components=1 \
+  "new-copilot-studio-tech-guide-${REF}/deploy" \
+  "new-copilot-studio-tech-guide-${REF}/sample/solution" \
+  || die "Extract failed."
+
+[ -f "$TMP/deploy/deploy.mjs" ] || die "deploy/deploy.mjs is missing after extract."
+
+# --- run ---------------------------------------------------------------------
+# deploy.mjs is interactive. When this script is piped to bash (curl | bash),
+# stdin is the script itself, so restore the terminal on /dev/tty for the prompts.
+cd "$TMP"
+say "Starting the guided deploy..."
+if [ -e /dev/tty ]; then
+  node deploy/deploy.mjs "$@" < /dev/tty
+else
+  node deploy/deploy.mjs "$@"
+fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -47,10 +47,13 @@ tar -xzf "$TMP/src.tgz" -C "$TMP" --strip-components=1 \
 
 # --- run ---------------------------------------------------------------------
 # deploy.mjs is interactive. When this script is piped to bash (curl | bash),
-# stdin is the script itself, so restore the terminal on /dev/tty for the prompts.
+# stdin is the script itself, so restore the terminal on /dev/tty for the
+# prompts — but only when /dev/tty is actually readable. In CI/headless shells
+# it may exist yet be unusable ("Device not configured"), and with --yes the
+# prompts never fire anyway, so fall back to the inherited stdin.
 cd "$TMP"
 say "Starting the guided deploy..."
-if [ -e /dev/tty ]; then
+if [ -e /dev/tty ] && (: < /dev/tty) 2>/dev/null; then
   node deploy/deploy.mjs "$@" < /dev/tty
 else
   node deploy/deploy.mjs "$@"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -59,6 +59,7 @@ const enableClarity = import.meta.env.PROD;
           <a href={`${base}#scenarios`}>Scenarios</a>
           <a href={`${base}#get-started`}>Get started</a>
           <a href={`${base}#resources`}>Resources</a>
+          <a href={`${base}faq`}>FAQ</a>
           <button id="skin-toggle" class="skin-toggle" type="button" aria-pressed="false" aria-label="Toggle immersive BlastBox skin">
             <span class="skin-toggle__dot"></span>
             <span class="skin-toggle__text">Theme</span>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,0 +1,119 @@
+---
+import Base from '../layouts/Base.astro';
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Base
+  title="Agents & Workflows FAQ | Copilot Studio technical guide"
+  description="Straight answers on upgrading agents, building on the GitHub Copilot harness, and what happens to topics, prompts, adaptive cards, and child agents in Copilot Studio."
+>
+  <article class="faq-page">
+    <div class="container">
+      <a href={base} class="back">&larr; Back to the guide</a>
+
+      <header class="faq-page__header">
+        <p class="section-label">FAQ</p>
+        <h1>Agents &amp; Workflows</h1>
+        <p class="faq-page__lead">
+          Common questions about moving to the new agent and workflow model in Copilot
+          Studio &mdash; when to upgrade, what to build on the GitHub Copilot harness, and
+          where topics, prompts, adaptive cards, and child agents land.
+        </p>
+      </header>
+
+      <div class="faq__list">
+        <details class="faq__item" open>
+          <summary class="faq__q">Do I need to upgrade each and every agent?<span class="faq__chev" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></summary>
+          <div class="faq__a"><p>If it does the job, don&apos;t rush into an upgrade. Standard agents already running in production can stay as-is; upgrade when there&apos;s a clear reason to.</p></div>
+        </details>
+        <details class="faq__item">
+          <summary class="faq__q">Do I build every new agent on the GHCP harness?<span class="faq__chev" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></summary>
+          <div class="faq__a"><p>If you want to automate with AI, you probably want a workflow with AI nodes. But if it&apos;s conversational and doesn&apos;t need to handle complex tasks, you can also build declarative agents in Agent Builder or Copilot Studio (the latter is upcoming).</p></div>
+        </details>
+        <details class="faq__item">
+          <summary class="faq__q">What happens to topics? Are they coming back?<span class="faq__chev" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></summary>
+          <div class="faq__a"><p>Not likely. The mental model: if topics are used to drive the conversational flows, then instructions and/or skills; if they are used to transform data, then code execution in the sandbox or workflows.</p></div>
+        </details>
+        <details class="faq__item">
+          <summary class="faq__q">What happens to prompts?<span class="faq__chev" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></summary>
+          <div class="faq__a"><p>Prompts are no longer the unit of work. In workflows, prompts become inline agents. In agents, the functionality of the prompt may be turned into a skill in most cases. Rethink what the workload needs and map it to the relevant component.</p></div>
+        </details>
+        <details class="faq__item">
+          <summary class="faq__q">What happens to adaptive cards?<span class="faq__chev" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></summary>
+          <div class="faq__a"><p>Rich UI component options in agents are still being actively worked on.</p></div>
+        </details>
+        <details class="faq__item">
+          <summary class="faq__q">What happens to child agents?<span class="faq__chev" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span></summary>
+          <div class="faq__a"><p>We have a cleaner model now with connected agents: less overlap, and most of the role that child agents played can be covered by skills.</p></div>
+        </details>
+      </div>
+
+      <aside class="faq-page__next">
+        <div>
+          <h2>See it in practice</h2>
+          <p>The fastest way to answer these for yourself is to deploy the sample and poke at it.</p>
+        </div>
+        <a href={`${base}#get-started`} class="btn btn--primary">Deploy the sample</a>
+      </aside>
+    </div>
+  </article>
+</Base>
+
+<style>
+  .faq-page { padding: var(--space-2xl) 0 var(--space-3xl); }
+  .back {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: 0.85rem; font-weight: 600; color: var(--c-text-muted);
+    margin-bottom: var(--space-xl);
+  }
+  .back:hover { color: var(--c-primary); }
+  .faq-page__header { max-width: 760px; }
+  .faq-page__header h1 {
+    margin-top: var(--space-sm);
+    font-family: var(--font-display); letter-spacing: 0.01em;
+    font-size: clamp(1.9rem, 4vw, 2.6rem);
+  }
+  .faq-page__lead {
+    margin-top: var(--space-md);
+    color: var(--c-text-secondary); font-size: 1.05rem; line-height: 1.7;
+  }
+
+  .faq__list {
+    margin-top: var(--space-2xl);
+    display: flex; flex-direction: column; gap: var(--space-sm);
+    max-width: 820px;
+  }
+  .faq__item {
+    background: var(--c-surface);
+    border: 1px solid var(--c-border-subtle);
+    border-radius: var(--radius-md);
+    transition: border-color 0.2s ease;
+  }
+  .faq__item:hover, .faq__item[open] { border-color: var(--c-border); }
+  .faq__q {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--space-md);
+    padding: var(--space-md) var(--space-lg);
+    font-size: 0.98rem; font-weight: 600; color: var(--c-text);
+    cursor: pointer; list-style: none;
+  }
+  .faq__q::-webkit-details-marker { display: none; }
+  .faq__q:hover { color: var(--c-primary); }
+  .faq__chev { flex-shrink: 0; color: var(--c-text-muted); display: inline-flex; transition: transform 0.2s ease, color 0.2s ease; }
+  .faq__item[open] .faq__chev { transform: rotate(180deg); color: var(--c-primary); }
+  .faq__a { padding: 0 var(--space-lg) var(--space-lg); }
+  .faq__a p { font-size: 0.9rem; color: var(--c-text-secondary); line-height: 1.7; max-width: 68ch; }
+
+  .faq-page__next {
+    margin-top: var(--space-3xl);
+    max-width: 820px;
+    display: flex; align-items: center; justify-content: space-between; gap: var(--space-xl);
+    flex-wrap: wrap;
+    padding: var(--space-xl);
+    background: var(--gradient-brand-soft), var(--c-surface);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-lg);
+  }
+  .faq-page__next h2 { font-size: 1.15rem; }
+  .faq-page__next p { margin-top: 4px; font-size: 0.9rem; color: var(--c-text-secondary); }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ const base = import.meta.env.BASE_URL;
           Copilot Studio
         </div>
         <h1 class="hero__title">
-          <span class="t-cat">The <span class="hero__title-accent">Copilot Studio</span> experience</span>
+          <span class="t-cat">Experience <span class="hero__title-accent">Copilot Studio</span></span>
           <span class="t-bb">BlastBox <span class="hero__title-omega">Omega</span></span>
         </h1>
         <p class="hero__tagline">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,20 +19,19 @@ const base = import.meta.env.BASE_URL;
           <span class="t-bb">BlastBox <span class="hero__title-omega">Omega</span></span>
         </h1>
         <p class="hero__tagline">
-          <span class="t-cat">A hands-on guide to Agents and Workflows in Copilot Studio.</span>
+          <span class="t-cat">Ready-to-run samples for Agents and Workflows in Copilot Studio.</span>
           <span class="t-bb">The retro-future game store, run by agents.</span>
         </p>
         <p class="hero__subtitle">
           <span class="t-cat">
-            Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
-            moving from a single chatbot to coordinated, multi-agent systems on the
-            <strong>GitHub Copilot harness</strong> &mdash; its agentic build, where the
-            agent reasons, acts, and adapts in a continuous loop. This is a
-            <strong>technical guide from the CAT team</strong> on building enterprise-grade
-            scenarios on that foundation: practical patterns for <strong>connected
-            agents</strong>, <strong>MCP servers</strong>, <strong>runtime skills</strong>,
-            and <strong>generated files</strong>, each one backed by a complete, runnable
-            reference you can deploy and inspect.
+            Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong> &mdash;
+            coordinated, multi-agent systems on the <strong>GitHub Copilot harness</strong>,
+            where the agent reasons, acts, and adapts in a loop. The fastest way to understand
+            it is to run it. This guide from the CAT team is built around <strong>complete,
+            ready-to-run samples</strong>: deploy one into a Power Platform environment you
+            already have and watch <strong>connected agents</strong>, <strong>MCP servers</strong>,
+            <strong>runtime skills</strong>, and <strong>generated files</strong> work together
+            end to end.
           </span>
           <span class="t-bb">
             Copilot Studio has been <strong>rebuilt for complex, multi-step work</strong>,
@@ -48,7 +47,7 @@ const base = import.meta.env.BASE_URL;
         </p>
         <div class="hero__actions">
           <a href="#scenarios" class="btn btn--primary">Explore scenarios</a>
-          <a href="https://github.com/microsoft/new-copilot-studio-tech-guide/tree/main/sample/solution" class="btn btn--secondary">
+          <a href="#get-started" class="btn btn--secondary">
             Get the sample
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
           </a>
@@ -73,82 +72,6 @@ const base = import.meta.env.BASE_URL;
             <div class="msg msg--bot">Warranty swap to MEGA &middot; refund $76.66 applied &middot; <strong>net due $23.34</strong>.</div>
             <div class="file"><span class="file__icon"><span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></span><span class="ticon-bb">&#128196;</span></span> blastbox_slip.pdf <span class="file__meta">generated</span></div>
           </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Pillars -->
-  <section class="pillars">
-    <div class="container">
-      <p class="section-label">What it shows</p>
-      <h2>The building blocks of the agent experience</h2>
-      <p class="pillars__intro">Every scenario is built from the same core capabilities of the Copilot Studio agent experience. The more advanced scenarios simply bring more of them together at once.</p>
-
-      <div class="pillars__grid">
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-primary);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#129309;</span>
-          </div>
-          <h3>Connected agents</h3>
-          <p>A parent agent delegates to specialist child agents and weaves their answers back into a single conversation.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-purple);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><polyline points="3 6 4 7 6 5"/><polyline points="3 12 4 13 6 11"/><polyline points="3 18 4 19 6 17"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#128221;</span>
-          </div>
-          <h3>AI Skills</h3>
-          <p>Reusable procedures the agent follows to get a task done, and they can reference assets like scripts and templates along the way.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-red);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#128013;</span>
-          </div>
-          <h3>Agent Sandbox</h3>
-          <p>Agents <em>generate and run code at runtime</em> to compute, transform, and analyze, going beyond text to real calculation.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-orange);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#128196;</span>
-          </div>
-          <h3>File Generation</h3>
-          <p>Agents produce real deliverables, PDFs, images, and documents, that users can download and hand off.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-green);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#128260;</span>
-          </div>
-          <h3>Adaptive Orchestration</h3>
-          <p>The agent plans dynamically across turns, asks for clarification when a step is ambiguous, and revises its plan when the request changes.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-pink);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 5v6c0 1.66-4 3-9 3s-9-1.34-9-3V5"/><path d="M21 11v6c0 1.66-4 3-9 3s-9-1.34-9-3v-6"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#129504;</span>
-          </div>
-          <h3>Memory</h3>
-          <p>Context and earlier results persist across the conversation, so the agent builds on what is already known instead of starting over.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-teal);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#128218;</span>
-          </div>
-          <h3>Knowledge</h3>
-          <p>Grounded answers from connected sources, documents, sites, and structured data.</p>
-        </div>
-        <div class="pillar">
-          <div class="pillar__icon" style="--g: var(--c-indigo);">
-            <span class="ticon-cat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="8" rx="2"/><rect x="2" y="14" width="20" height="8" rx="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg></span>
-            <span class="ticon-bb" style="font-size:1.4rem;">&#128736;&#65039;</span>
-          </div>
-          <h3>Tools/MCP Servers</h3>
-          <p>Agents call external systems and APIs as tools through MCP servers and connectors, extending what they can do beyond built-in capabilities.</p>
         </div>
       </div>
     </div>
@@ -193,34 +116,40 @@ const base = import.meta.env.BASE_URL;
           pillars={["3 connected agents", "live charts", "policy-bound recs", "manager PDF"]}
           upcoming={true}
         />
+      </div>
     </div>
   </section>
 
   <!-- Get started -->
   <section class="cta" id="get-started">
     <div class="container">
-      <div class="cta__layout">
-        <div class="cta__text">
-          <p class="section-label">Get started</p>
-          <h2>Stand up the store</h2>
-          <p class="cta__desc">Import the solution, create the MCP connections, add the policy documents, publish the agents, then run the scripted prompts. Everything runs inside Power Platform. No servers, no code to host.</p>
-          <div class="cta__actions">
-            <a href="https://github.com/microsoft/new-copilot-studio-tech-guide/tree/main/sample/solution" class="btn btn--primary">
-              Get the sample
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
-            </a>
-            <a href="https://github.com/microsoft/new-copilot-studio-tech-guide" class="btn btn--secondary">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              GitHub repo
-            </a>
+      <div class="cta__card">
+        <div class="cta__top">
+          <div class="cta__intro">
+            <p class="section-label">Get started</p>
+            <h2>Stand up the store</h2>
+            <p class="cta__desc">One command downloads the sample and deploys all four agents and their MCP connectors into a Power Platform environment you already have &mdash; no clone, no servers, nothing to host. A few minutes later you have a running store to explore.</p>
+            <p class="cta__note">Needs the <a href="https://learn.microsoft.com/power-platform/developer/cli/introduction" target="_blank" rel="noopener">pac CLI</a> (signed in) and <a href="https://learn.microsoft.com/cli/azure/install-azure-cli" target="_blank" rel="noopener">az CLI</a>. Prefer to clone? Grab the <a href="https://github.com/microsoft/new-copilot-studio-tech-guide/tree/main/sample/solution">sample</a> and run <code>node deploy/deploy.mjs</code>.</p>
+          </div>
+          <div class="term" role="group" aria-label="Deploy commands">
+            <div class="term__bar" aria-hidden="true">
+              <span class="term__dot"></span><span class="term__dot"></span><span class="term__dot"></span>
+              <span class="term__title">deploy the sample</span>
+            </div>
+            <div class="term__body">
+              <p class="term__comment"># macOS / Linux</p>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash</code></div>
+              <p class="term__comment"># Windows &middot; PowerShell</p>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex</code></div>
+            </div>
           </div>
         </div>
-        <div class="cta__steps">
-          <div class="cta__step"><span class="cta__num">1</span><div><strong>Import the solution</strong><p>Upload the managed zip in Power Apps</p></div></div>
-          <div class="cta__step"><span class="cta__num">2</span><div><strong>Publish all customizations</strong><p>Deploys the inline connector code to APIM</p></div></div>
-          <div class="cta__step"><span class="cta__num">3</span><div><strong>Create MCP connections</strong><p>Click Create for each of the four connectors</p></div></div>
-          <div class="cta__step"><span class="cta__num">4</span><div><strong>Publish &amp; play</strong><p>Publish all four agents, then run the two scenarios</p></div></div>
-        </div>
+        <ol class="cta__steps">
+          <li class="cta__step"><span class="cta__num">1</span><div class="cta__step-body"><strong>Run the one-liner</strong><p>Pick your pac profile and target environment when it asks.</p></div></li>
+          <li class="cta__step"><span class="cta__num">2</span><div class="cta__step-body"><strong>It deploys</strong><p>Imports both solutions, deploys the MCP connectors, creates connections, publishes the agents.</p></div></li>
+          <li class="cta__step"><span class="cta__num">3</span><div class="cta__step-body"><strong>Re-attach MCP tools</strong><p>One ~2-minute manual UI step it prints at the end.</p></div></li>
+          <li class="cta__step"><span class="cta__num">4</span><div class="cta__step-body"><strong>Play the scenarios</strong><p>Open each agent&apos;s Preview and run the walkthroughs above.</p></div></li>
+        </ol>
       </div>
     </div>
   </section>
@@ -230,7 +159,7 @@ const base = import.meta.env.BASE_URL;
     <div class="container">
       <p class="section-label">Go deeper</p>
       <h2>Resources</h2>
-      <p class="resources__intro">Reference material to help you understand and extend agents in Copilot Studio, a technical deep dive on agents and the open-source plugin that ties into it.</p>
+      <p class="resources__intro">Reference material to go further: a technical deep-dive deck, the open-source plugin that upgrades and builds agents, and straight answers to the common questions.</p>
 
       <div class="resources__grid">
         <div class="resource resource--deck" style="--accent: var(--c-purple);">
@@ -268,9 +197,25 @@ const base = import.meta.env.BASE_URL;
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><polyline points="7 7 17 7 17 17"/></svg>
           </span>
         </a>
+
+        <a href={`${base}faq`} class="resource resource--faq" style="--accent: var(--c-orange);">
+          <div class="resource__head">
+            <span class="resource__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            </span>
+            <span class="resource__kind">FAQ &middot; 6 answers</span>
+          </div>
+          <h3 class="resource__title">Agents &amp; Workflows FAQ</h3>
+          <p class="resource__desc">Straight answers on upgrading agents, building on the GHCP harness, and what happens to topics, prompts, adaptive cards, and child agents.</p>
+          <span class="resource__link">
+            Read the FAQ
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
+          </span>
+        </a>
       </div>
     </div>
   </section>
+
 </Base>
 
 <style>
@@ -387,37 +332,6 @@ const base = import.meta.env.BASE_URL;
   .file__icon { background: var(--tint-orange); color: var(--c-orange); display: inline-flex; padding: 3px; }
   .file__icon svg { width: 13px; height: 13px; }
 
-  /* ── Pillars ── */
-  .pillars { padding: var(--space-2xl) 0; }
-  .pillars__intro { color: var(--c-text-secondary); margin-top: var(--space-sm); max-width: 44rem; }
-  .pillars__grid {
-    margin-top: var(--space-2xl);
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-    gap: var(--space-lg);
-  }
-  .pillar {
-    padding: var(--space-lg);
-    background: var(--c-surface);
-    border: 1px solid var(--c-border-subtle);
-    border-radius: var(--radius-md);
-    transition: border-color 0.2s, transform 0.2s;
-  }
-  .pillar:hover { border-color: var(--c-border); transform: translateY(-2px); }
-  .pillar__icon {
-    width: 44px; height: 44px;
-    display: flex; align-items: center; justify-content: center;
-    color: var(--g);
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--g) 12%, transparent);
-    border: 1px solid color-mix(in srgb, var(--g) 35%, transparent);
-    margin-bottom: var(--space-md);
-  }
-  .pillar__icon svg { width: 22px; height: 22px; }
-  .pillar h3 { font-size: 1rem; margin-bottom: var(--space-xs); }
-  .pillar p { font-size: 0.86rem; color: var(--c-text-secondary); line-height: 1.6; }
-  .pillar em { color: var(--c-text); font-style: normal; font-weight: 600; }
-
   /* ── Scenarios ── */
   .scenarios { padding: var(--space-2xl) 0; scroll-margin-top: 70px; }
   .scenarios__intro { color: var(--c-text-secondary); margin-top: var(--space-sm); max-width: 44rem; }
@@ -434,9 +348,9 @@ const base = import.meta.env.BASE_URL;
   .resources__grid {
     margin-top: var(--space-2xl);
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--space-lg);
-    max-width: 780px;
+    max-width: 1000px;
   }
   .resource {
     --accent: var(--c-primary);
@@ -533,41 +447,107 @@ const base = import.meta.env.BASE_URL;
   .resource__feedback:hover { color: var(--accent); }
   .resource__feedback svg { opacity: 0.7; }
 
+  @media (max-width: 900px) {
+    .resources__grid { grid-template-columns: repeat(2, 1fr); max-width: 680px; }
+  }
   @media (max-width: 640px) {
     .resources__grid { grid-template-columns: 1fr; }
   }
 
   /* ── CTA ── */
+  /* ── Get started ── */
   .cta { padding: var(--space-2xl) 0; scroll-margin-top: 70px; }
-  .cta__layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-3xl);
-    align-items: center;
+  .cta__card {
     padding: var(--space-2xl);
     background: var(--gradient-brand-soft), var(--c-surface);
     border: 1px solid var(--c-border);
     border-radius: var(--radius-xl);
   }
+  .cta__top {
+    display: grid;
+    grid-template-columns: 1fr 1.15fr;
+    gap: var(--space-2xl);
+    align-items: start;
+  }
   .cta__desc { margin-top: var(--space-sm); color: var(--c-text-secondary); line-height: 1.7; }
-  .cta__actions { display: flex; gap: var(--space-md); margin-top: var(--space-lg); flex-wrap: wrap; }
-  .cta__steps { display: flex; flex-direction: column; gap: var(--space-md); }
+  .cta__note { margin-top: var(--space-lg); font-size: 0.8rem; color: var(--c-text-muted); line-height: 1.65; }
+  .cta__note a { color: var(--c-primary); font-weight: 600; }
+  .cta__note code {
+    font-family: var(--font-mono); font-size: 0.76rem;
+    background: var(--c-surface-raised); border: 1px solid var(--c-border-subtle);
+    padding: 1px 5px; border-radius: 4px;
+  }
+
+  /* Terminal window carrying the deploy one-liners */
+  .term {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-lg);
+    background: var(--c-dark);
+    overflow: hidden;
+    box-shadow: 0 20px 44px -28px rgba(0, 0, 0, 0.55);
+  }
+  .term__bar {
+    display: flex; align-items: center; gap: 7px;
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--c-dark) 80%, #ffffff);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .term__dot { width: 11px; height: 11px; border-radius: 50%; }
+  .term__dot:nth-child(1) { background: #ff5f57; }
+  .term__dot:nth-child(2) { background: #febc2e; }
+  .term__dot:nth-child(3) { background: #28c840; }
+  .term__title {
+    margin-left: 6px;
+    font-family: var(--font-mono); font-size: 0.72rem; font-weight: 600;
+    letter-spacing: 0.02em; color: rgba(255, 255, 255, 0.5);
+  }
+  .term__body { padding: var(--space-lg); }
+  .term__comment {
+    margin: var(--space-lg) 0 8px;
+    font-family: var(--font-mono); font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.42);
+  }
+  .term__body > .term__comment:first-child { margin-top: 0; }
+  .term__cmd { padding: 0; }
+  .term__cmd .try-prompt__text {
+    display: block;
+    font-family: var(--font-mono); font-size: 0.8rem; line-height: 1.65;
+    color: #e8eaed;
+    white-space: pre-wrap; overflow-wrap: anywhere;
+    padding-left: 1.35em; text-indent: -1.35em; padding-right: 92px;
+  }
+  .term__cmd .try-prompt__text::before { content: "$ "; color: #28c840; font-weight: 700; }
+
+  /* Post-install sequence */
+  .cta__steps {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-lg);
+    margin-top: var(--space-2xl);
+    padding-top: var(--space-xl);
+    border-top: 1px solid var(--c-border);
+  }
   .cta__step { display: flex; align-items: flex-start; gap: var(--space-md); }
   .cta__num {
     flex-shrink: 0;
     width: 30px; height: 30px;
     display: flex; align-items: center; justify-content: center;
     font-family: var(--font-display); font-weight: 800; font-size: 0.82rem;
-    color: var(--c-bg-deep);
+    color: var(--c-on-primary);
     background: var(--c-primary);
     border-radius: 8px;
   }
-  .cta__step strong { font-size: 0.92rem; }
-  .cta__step p { font-size: 0.82rem; color: var(--c-text-muted); }
+  .cta__step-body strong { font-size: 0.9rem; display: block; }
+  .cta__step-body p { margin-top: 3px; font-size: 0.82rem; color: var(--c-text-muted); line-height: 1.5; }
 
   @media (max-width: 860px) {
     .hero__inner { grid-template-columns: 1fr; gap: var(--space-2xl); }
     .hero__visual { order: -1; }
-    .cta__layout { grid-template-columns: 1fr; gap: var(--space-xl); }
+    .cta__top { grid-template-columns: 1fr; gap: var(--space-xl); }
+    .cta__steps { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 560px) {
+    .cta__steps { grid-template-columns: 1fr; }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,10 +10,6 @@ const base = import.meta.env.BASE_URL;
   <section class="hero">
     <div class="container hero__inner">
       <div class="hero__content">
-        <div class="hero__eyebrow">
-          <span class="hero__eyebrow-dot">&#9670;</span>
-          Copilot Studio
-        </div>
         <h1 class="hero__title">
           <span class="t-cat">Experience <span class="hero__title-accent">Copilot Studio</span></span>
           <span class="t-bb">BlastBox <span class="hero__title-omega">Omega</span></span>
@@ -140,7 +136,7 @@ const base = import.meta.env.BASE_URL;
               <p class="term__comment"># macOS / Linux</p>
               <div class="try-prompt term__cmd"><code class="try-prompt__text">curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash</code></div>
               <p class="term__comment"># Windows &middot; PowerShell</p>
-              <div class="try-prompt term__cmd"><code class="try-prompt__text">irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex</code></div>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"</code></div>
             </div>
           </div>
         </div>
@@ -227,22 +223,6 @@ const base = import.meta.env.BASE_URL;
     gap: var(--space-3xl);
     align-items: center;
   }
-  .hero__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--c-text-secondary);
-    border: 1px solid var(--c-border);
-    background: var(--c-surface);
-    padding: 5px 12px;
-    border-radius: 20px;
-  }
-  .hero__eyebrow-dot { color: var(--c-primary); text-shadow: var(--glow-accent); }
   .hero__title {
     font-family: var(--font-display);
     font-size: clamp(2.6rem, 6.5vw, 4.4rem);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -511,10 +511,14 @@ const base = import.meta.env.BASE_URL;
   .term__cmd { padding: 0; }
   .term__cmd .try-prompt__text {
     display: block;
-    font-family: var(--font-mono); font-size: 0.8rem; line-height: 1.65;
+    font-family: var(--font-mono); font-size: 0.8rem; line-height: 1.7;
     color: #e8eaed;
+    background: transparent;
+    border: none;
+    border-radius: 0;
     white-space: pre-wrap; overflow-wrap: anywhere;
-    padding-left: 1.35em; text-indent: -1.35em; padding-right: 92px;
+    padding: 2px 92px 2px 1.35em;
+    text-indent: -1.35em;
   }
   .term__cmd .try-prompt__text::before { content: "$ "; color: #28c840; font-weight: 700; }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -134,9 +134,9 @@ const base = import.meta.env.BASE_URL;
             </div>
             <div class="term__body">
               <p class="term__comment"># macOS / Linux</p>
-              <div class="try-prompt term__cmd"><code class="try-prompt__text">curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.sh | BLASTBOX_REF=sample-first-installer bash</code></div>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash</code></div>
               <p class="term__comment"># Windows &middot; PowerShell</p>
-              <div class="try-prompt term__cmd"><code class="try-prompt__text">powershell -c "$env:BLASTBOX_REF='sample-first-installer'; irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.ps1 | iex"</code></div>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"</code></div>
             </div>
           </div>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -134,9 +134,9 @@ const base = import.meta.env.BASE_URL;
             </div>
             <div class="term__body">
               <p class="term__comment"># macOS / Linux</p>
-              <div class="try-prompt term__cmd"><code class="try-prompt__text">curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.sh | bash</code></div>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">curl -fsSL https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.sh | BLASTBOX_REF=sample-first-installer bash</code></div>
               <p class="term__comment"># Windows &middot; PowerShell</p>
-              <div class="try-prompt term__cmd"><code class="try-prompt__text">powershell -c "irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/main/deploy/install.ps1 | iex"</code></div>
+              <div class="try-prompt term__cmd"><code class="try-prompt__text">powershell -c "$env:BLASTBOX_REF='sample-first-installer'; irm https://raw.githubusercontent.com/microsoft/new-copilot-studio-tech-guide/sample-first-installer/deploy/install.ps1 | iex"</code></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What & why
Reorients the guide's home page around the **runnable sample** (deploy-it-and-experience-it) rather than a wall of harness capabilities, and makes it trivial to stand up.

### Changes
- **Sample-first home page** — lead with the sample and the scenarios you can run; capabilities/resources (plugin, deck, FAQ) become supporting material.
- **No-clone one-liner install** — `deploy/install.sh` (macOS/Linux) and `deploy/install.ps1` (Windows) bootstrap the guided deploy straight from GitHub. New **Get started / "Stand up the store"** section.
- **FAQ moved to its own page** (`/faq`), off the homepage.
- **Design polish** — fix washed-out terminal command text; active hero headline ("Experience Copilot Studio"); drop the redundant hero eyebrow; Windows one-liner is paste-anywhere (`powershell -c "…"`).
- **install.sh robustness** — fall back to inherited stdin when `/dev/tty` exists but is unusable (headless `curl | bash` / CI), so the deploy isn't aborted before it starts.

### Verified
Ran the **macOS one-liner end-to-end** into a fresh Power Platform Developer environment: both solutions imported + published, all 4 MCP connectors' code deployed, 4 no-auth connections Connected, and all 4 agents published — clean exit. The one manual MCP re-attach step (no API) is printed at the end by design.

The one-liner points at `main`; the raw URL resolves once this merges.
