### PR TITLE
Fix install.ps1 MAX_PATH failure on Windows PowerShell 5.1

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -18,6 +18,51 @@ $ref  = if ($env:BLASTBOX_REF) { $env:BLASTBOX_REF } else { 'main' }
 function Info($m) { Write-Host "==> $m" -ForegroundColor Cyan }
 function Warn($m) { Write-Host "WARNING: $m" -ForegroundColor Yellow }
 
+# Extract only the deploy/ and sample/solution/ subtrees (everything deploy.mjs
+# needs), stripping the top "<repo>-<ref>/" folder. Entries are written through
+# \\?\ extended-length paths so Windows PowerShell 5.1 does not trip over the
+# 260-char MAX_PATH limit on the deeply nested solution component files -- plain
+# Expand-Archive fails there and masks it with a misleading Remove-Item error.
+function Expand-DeployAssets {
+  param(
+    [Parameter(Mandatory)][string] $ZipPath,
+    [Parameter(Mandatory)][string] $Destination,
+    [Parameter(Mandatory)][string] $Ref
+  )
+  if (-not ('System.IO.Compression.ZipFile' -as [type])) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+  }
+  $dest = [System.IO.Path]::GetFullPath($Destination).TrimEnd('\')
+  $top  = "new-copilot-studio-tech-guide-$Ref/"
+  $want = @("${top}deploy/", "${top}sample/solution/")
+  $archive = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+  try {
+    foreach ($entry in $archive.Entries) {
+      $name = $entry.FullName
+      if (-not ($want | Where-Object { $name.StartsWith($_, [System.StringComparison]::Ordinal) })) { continue }
+      $rel = $name.Substring($top.Length) -replace '/', '\'
+      if ([string]::IsNullOrEmpty($rel)) { continue }
+      $target = "$dest\$rel"
+      if ([string]::IsNullOrEmpty($entry.Name)) {
+        [void][System.IO.Directory]::CreateDirectory("\\?\$($target.TrimEnd('\'))")
+        continue
+      }
+      [void][System.IO.Directory]::CreateDirectory("\\?\$([System.IO.Path]::GetDirectoryName($target))")
+      [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, "\\?\$target", $true)
+    }
+  }
+  finally { $archive.Dispose() }
+}
+
+# Best-effort recursive delete that also copes with >260-char paths.
+function Remove-TreeLongPath {
+  param([Parameter(Mandatory)][string] $Path)
+  if (-not (Test-Path -LiteralPath $Path)) { return }
+  $full = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+  try { [System.IO.Directory]::Delete("\\?\$full", $true) }
+  catch { Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
 # --- preflight ---------------------------------------------------------------
 if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
   throw 'Node.js 18+ is required but was not found. Install it from https://nodejs.org and re-run.'
@@ -32,16 +77,18 @@ if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
 }
 
 # --- download ----------------------------------------------------------------
-$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("blastbox-" + [guid]::NewGuid().ToString('N'))
-New-Item -ItemType Directory -Path $tmp | Out-Null
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("bb-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
 try {
   $zip = Join-Path $tmp 'src.zip'
   Info "Downloading the sample ($repo@$ref)..."
   Invoke-WebRequest -Uri "https://codeload.github.com/$repo/zip/refs/heads/$ref" -OutFile $zip -UseBasicParsing
 
   Info 'Extracting the deploy assets...'
-  Expand-Archive -Path $zip -DestinationPath $tmp -Force
-  $root = Join-Path $tmp "new-copilot-studio-tech-guide-$ref"
+  # Mirrors install.sh: only deploy/ + sample/solution/, top folder stripped, so
+  # $tmp becomes REPO_ROOT (deploy.mjs resolves REPO_ROOT as deploy/..).
+  Expand-DeployAssets -ZipPath $zip -Destination $tmp -Ref $ref
+  $root = $tmp
   if (-not (Test-Path (Join-Path $root 'deploy\deploy.mjs'))) {
     throw 'deploy/deploy.mjs is missing after extract.'
   }
@@ -57,5 +104,5 @@ try {
   finally { Pop-Location }
 }
 finally {
-  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+  Remove-TreeLongPath -Path $tmp
 }


### PR DESCRIPTION
## Problem

Running the Windows no-clone bootstrap under Windows PowerShell 5.1 fails during extraction:

```
Remove-Item : Cannot find path '...\new-copilot-studio-tech-guide-main\.env.example' because it does not exist.
At ...\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1:411 char:46
```

The `.env.example` error is a **red herring**. `install.ps1` did a full `Expand-Archive` of the repo zip, keeping the `new-copilot-studio-tech-guide-<ref>/` wrapper folder. The deepest solution component file then extracts to:

```
%TEMP%\blastbox-<32hex>\new-copilot-studio-tech-guide-main\sample\solution\src\BlastBoxAgents\botcomponents\cr26e_...Default_InventoryFullfilmentAgent_X-w2GP\dependencies.json
```

≈ **279 chars — past the Windows 260-char `MAX_PATH` limit**. Windows PowerShell 5.1's `Expand-Archive` has no long-path support, so it throws; its internal catch cleanup (`$expandedItems | % { Remove-Item $_ -Force -Recurse }` at `psm1:411`) then surfaces the misleading `.env.example` "not found" instead of the real error, and `$ErrorActionPreference='Stop'` makes it fatal. Only `powershell` (WinPS 5.1) is affected — `install.sh` already sidesteps this by extracting a narrow subtree with `--strip-components=1`.

## Fix

Make `install.ps1` mirror `install.sh` and be long-path safe:

- Extract **only** `deploy/` + `sample/solution/` (everything `deploy.mjs` needs — it resolves `REPO_ROOT = deploy/..` and reads assets from `sample/solution/`) and **strip the top wrapper folder**. Worst-case path drops **279 → 214** chars.
- Write each entry through `\\?\` extended-length paths, so extraction is immune to `MAX_PATH` regardless of username/temp length.
- Shorter temp dir name + a `\\?\`-safe recursive cleanup so nothing is left behind.

## Verification

- `install.ps1` parses cleanly (`[Parser]::ParseFile`).
- Functional test against a synthetic GitHub-style zip: only `deploy/` + `sample/solution/` extract (including the deep 200-char component file), wrapper folder stripped, and `.env.example` / `site/` / `sample/archive/` skipped; `deploy/deploy.mjs` lands as a sibling of `sample/solution/` so `REPO_ROOT` resolves correctly.
- Path-length math confirmed: old scheme 279 (> 260, fails), new scheme 214 (< 260), and `\\?\` covers the rest.