### PR TITLE
Add compact overview to Block Party Trade-Up scenario

### DIFF
--- a/src/pages/scenarios/block-party-trade-up.astro
+++ b/src/pages/scenarios/block-party-trade-up.astro
@@ -186,6 +186,65 @@ const base = import.meta.env.BASE_URL;
           </a>
         </figure>
       </section>
+
+      <section class="scenario__section journey-overview" aria-labelledby="journey-overview-title">
+        <h2 id="journey-overview-title">The scenario at a glance</h2>
+        <p class="journey-overview__intro">
+          A simple request hides a complex service journey. The agent keeps the systems,
+          calculations, and customer conversation moving together.
+        </p>
+
+        <figure class="journey-compare">
+          <div class="journey-compare__panel">
+            <div class="journey-compare__heading">
+              <h3>Human-supported process</h3>
+              <span class="journey-compare__badge">Fragmented</span>
+            </div>
+            <ul class="journey-compare__tasks">
+              <li>Validate purchase and defect</li>
+              <li>Interpret warranty policy</li>
+              <li>Check stock and alternatives</li>
+              <li>Calculate refund and upgrade</li>
+              <li>Reconcile membership and loyalty</li>
+              <li>Complete return and paperwork</li>
+            </ul>
+            <p class="journey-compare__summary">
+              The associate must keep <strong>six workstreams</strong> in sync while the
+              customer waits.
+            </p>
+          </div>
+
+          <div class="journey-compare__arrow" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </div>
+
+          <div class="journey-compare__panel journey-compare__panel--agent">
+            <div class="journey-compare__heading">
+              <h3>With Store Associate Assistant</h3>
+              <span class="journey-compare__badge">Orchestrated</span>
+            </div>
+            <div class="journey-compare__agent-map">
+              <span>Policy</span>
+              <span>Inventory</span>
+              <strong>One conversation</strong>
+              <span>Membership</span>
+              <span>Orders</span>
+            </div>
+            <p class="journey-compare__summary">
+              The agent asks <strong>one clarifying question</strong>, presents the options,
+              executes the choice, and produces the settlement.
+            </p>
+          </div>
+
+          <figcaption class="journey-compare__outcome">
+            <span>Customer outcome</span>
+            Working console today &middot; membership credit applied &middot;
+            <strong>$23.34 due</strong> &middot; settlement PDF ready
+          </figcaption>
+        </figure>
+      </section>
     </div>
   </article>
 </Base>

--- a/src/styles/scenario.css
+++ b/src/styles/scenario.css
@@ -118,7 +118,40 @@
   color: var(--c-purple);
 }
 
+/* Compact before/after journey overview */
+.journey-overview { max-width: 900px; }
+.journey-overview__intro { max-width: 70ch; margin: calc(-1 * var(--space-sm)) 0 var(--space-lg); color: var(--c-text-secondary); font-size: 0.9rem; line-height: 1.6; }
+.journey-compare { display: grid; grid-template-columns: 1fr 44px 1fr; align-items: stretch; gap: 0; margin: 0; }
+.journey-compare__panel { display: grid; grid-template-rows: auto 1fr auto; gap: var(--space-md); min-width: 0; padding: var(--space-lg); background: var(--c-surface); border: 1px solid var(--c-border-subtle); border-radius: var(--radius-md); }
+.journey-compare__panel--agent { background: var(--gradient-brand-soft), var(--c-surface); border-color: var(--border-primary); }
+.journey-compare__heading { display: flex; align-items: center; justify-content: space-between; gap: var(--space-sm); }
+.journey-compare__heading h3 { margin: 0; font-family: var(--font-display); font-size: 0.95rem; color: var(--c-text); }
+.journey-compare__badge { flex-shrink: 0; padding: 3px 7px; border: 1px solid var(--c-border); border-radius: var(--radius-sm); color: var(--c-text-muted); background: var(--c-surface-raised); font-family: var(--font-mono); font-size: 0.56rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.journey-compare__panel--agent .journey-compare__badge { color: var(--c-primary); border-color: var(--border-primary); background: var(--c-primary-light); }
+.journey-compare__tasks { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; padding: 0; list-style: none; }
+.journey-compare__tasks li { position: relative; display: flex; align-items: center; min-height: 42px; padding: 7px 8px 7px 22px; border: 1px solid var(--c-border-subtle); border-radius: var(--radius-sm); color: var(--c-text-secondary); background: var(--c-surface-raised); font-size: 0.72rem; font-weight: 600; line-height: 1.3; }
+.journey-compare__tasks li::before { content: ""; position: absolute; left: 9px; width: 6px; height: 6px; border-radius: 50%; background: var(--c-text-muted); }
+.journey-compare__summary { padding-top: var(--space-sm); border-top: 1px solid var(--c-border-subtle); color: var(--c-text-secondary); font-size: 0.75rem; line-height: 1.5; }
+.journey-compare__summary strong { color: var(--c-text); }
+.journey-compare__arrow { display: flex; align-items: center; justify-content: center; color: var(--c-primary); }
+.journey-compare__arrow svg { width: 26px; height: 26px; }
+.journey-compare__agent-map { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; align-content: center; }
+.journey-compare__agent-map span { padding: 8px; border: 1px solid var(--c-border-subtle); border-radius: var(--radius-sm); color: var(--c-text-secondary); background: var(--c-surface); text-align: center; font-size: 0.7rem; font-weight: 700; }
+.journey-compare__agent-map strong { grid-column: 1 / -1; grid-row: 1; justify-self: center; padding: 10px 16px; border: 1px solid var(--c-primary); border-radius: var(--radius-md); color: var(--c-primary); background: var(--c-primary-light); font-family: var(--font-display); font-size: 0.82rem; text-align: center; }
+.journey-compare__outcome { grid-column: 1 / -1; display: flex; align-items: center; gap: var(--space-md); margin-top: var(--space-sm); padding: 10px var(--space-md); border: 1px solid var(--border-primary); border-radius: var(--radius-md); color: var(--c-text-secondary); background: var(--c-primary-light); font-size: 0.78rem; line-height: 1.45; }
+.journey-compare__outcome span { flex-shrink: 0; padding-right: var(--space-md); border-right: 1px solid var(--border-primary); color: var(--c-primary); font-family: var(--font-mono); font-size: 0.6rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.journey-compare__outcome strong { color: var(--c-text); }
+
 @media (max-width: 800px) {
   .scenario__tools { grid-template-columns: 1fr; }
   .demotype-copy { width: 100%; }
+  .journey-compare { grid-template-columns: 1fr; gap: var(--space-sm); }
+  .journey-compare__arrow { transform: rotate(90deg); }
+  .journey-compare__outcome { grid-column: 1; }
+}
+
+@media (max-width: 520px) {
+  .journey-compare__tasks { grid-template-columns: 1fr; }
+  .journey-compare__outcome { align-items: flex-start; flex-direction: column; gap: var(--space-sm); }
+  .journey-compare__outcome span { padding-right: 0; border-right: 0; }
 }


### PR DESCRIPTION
## Summary
- add a compact before/after visualization at the end of the Block Party Trade-Up scenario
- contrast the fragmented human-supported process with the Store Associate Assistant orchestration
- keep the overview responsive and compatible with both site themes

## Validation
- `npm run build`